### PR TITLE
fix: when a user's `rm` is aliased

### DIFF
--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -146,7 +146,7 @@ function __vf_rm --description "Delete a virtualenv"
 		return 1
 	end
 	echo "Removing $VIRTUALFISH_HOME/$argv[1]"
-	rm -rf $VIRTUALFISH_HOME/$argv[1]
+	command rm -rf $VIRTUALFISH_HOME/$argv[1]
 end
 
 function __vf_ls --description "List all of the available virtualenvs"
@@ -177,7 +177,7 @@ function __vf_tmp --description "Create a virtualenv that will be removed when d
 	# Use will_deactivate here so that $VIRTUAL_ENV is available.
 	function __vf_tmp_remove --on-event virtualenv_will_deactivate:$env_name
 		echo "Removing $VIRTUAL_ENV"
-		rm -rf $VIRTUAL_ENV
+		command rm -rf $VIRTUAL_ENV
         set -e VF_TEMPORARY_ENV
 	end
 
@@ -221,7 +221,7 @@ function __vf_addpath --description "Adds a path to sys.path in this virtualenv"
 '"$absolute_path"'
 ' "$path_file"
 			end
-	        rm -f "$path_file.tmp"
+	        command rm -f "$path_file.tmp"
 		end
 		return 0
 	else
@@ -293,7 +293,7 @@ function __vf_globalpackages --description "Toggle global site packages"
       cd lib/python*/site-packages/..
       if test -e $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
         echo "Enabling global site packages"
-        rm $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
+        command rm $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
       else
         echo "Disabling global site packages"
         touch $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE


### PR DESCRIPTION
**Action:** I prefixed all uses of `rm` in the code base with [command](https://fishshell.com/docs/current/commands.html#command) (making them `command rm`) in order to "_force the shell to execute the program COMMANDNAME and ignore any functions or builtins with the same name_" -[Fish: Command Reference](https://fishshell.com/docs/current/commands.html#command).

**Reason:** I've aliased `rm` on my machine to remind me to use a safer deletion method instead. Because virtualfish is dependent on the proper functioning of `rm`, `vf rm ENVIRONMENT` fails to cleanup the ENVIRONMENT's directory. To circumvent any aliasing of `rm`, and therefore any potential unexpected behaviour that could arise due to various user environments, I implemented the aforementioned changes.
