### PR TITLE
Don't rely on 'cat' to be '/bin/cat'

### DIFF
--- a/virtualfish/auto_activation.fish
+++ b/virtualfish/auto_activation.fish
@@ -11,7 +11,7 @@ function __vfsupport_auto_activate --on-variable PWD
     set -l new_virtualenv_name ""
     while test $activation_root != ""
         if test -f "$activation_root/$VIRTUALFISH_ACTIVATION_FILE"
-            set new_virtualenv_name (cat "$activation_root/$VIRTUALFISH_ACTIVATION_FILE")
+            set new_virtualenv_name (command cat "$activation_root/$VIRTUALFISH_ACTIVATION_FILE")
             break
         end
         # this strips the last path component from the path.


### PR DESCRIPTION
On my current setup, I created a function to overload `cat` so it does more, and this is breaking autoactivation because it returns more than what `/bin/cat` would.
By adding `command` in front of `cat` we ensure that `/bin/cat` (or wherever you have `cat` installed) gets run.