### PR TITLE
Add windows exe paths

### DIFF
--- a/virtualfish/__main__.py
+++ b/virtualfish/__main__.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     commands = [
         'set -g VIRTUALFISH_VERSION {}'.format(version),
         'set -g VIRTUALFISH_PYTHON_EXEC {}'.format(sys.executable),
-        'source {}'.format(os.path.join(base_path, 'virtual.fish')),
+        'source "{}"'.format(os.path.join(base_path, 'virtual.fish')),
     ]
 
     for plugin in sys.argv[1:]:

--- a/virtualfish/__main__.py
+++ b/virtualfish/__main__.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     for plugin in sys.argv[1:]:
         path = os.path.join(base_path, plugin + '.fish')
         if os.path.exists(path):
-            commands.append('source {}'.format(path))
+            commands.append('source "{}"'.format(path))
         else:
             print('virtualfish loader error: plugin {} does not exist!'.format(plugin), file=sys.stderr)
 

--- a/virtualfish/__main__.py
+++ b/virtualfish/__main__.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
     base_path = os.path.dirname(os.path.abspath(__file__))
     commands = [
         'set -g VIRTUALFISH_VERSION {}'.format(version),
-        'set -g VIRTUALFISH_PYTHON_EXEC {}'.format(sys.executable),
+        'set -g VIRTUALFISH_PYTHON_EXEC "{}"'.format(sys.executable),
         'source "{}"'.format(os.path.join(base_path, 'virtual.fish')),
     ]
 

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -139,7 +139,7 @@ function __vf_new --description "Create a new virtualenv"
         set argv "--python" $VIRTUALFISH_DEFAULT_PYTHON $argv
     end
     set -lx PIP_USER 0
-    eval $VIRTUALFISH_PYTHON_EXEC -m virtualenv $argv $VIRTUALFISH_HOME/$envname
+    eval (realpath $VIRTUALFISH_PYTHON_EXEC) -m virtualenv $argv $VIRTUALFISH_HOME/$envname
     set vestatus $status
     if begin; [ $vestatus -eq 0 ]; and [ -d $VIRTUALFISH_HOME/$envname ]; end
         vf activate $envname

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -136,10 +136,10 @@ function __vf_new --description "Create a new virtualenv"
     set envname $argv[-1]
     set -e argv[-1]
     if set -q VIRTUALFISH_DEFAULT_PYTHON
-        set argv "--python" $VIRTUALFISH_DEFAULT_PYTHON $argv
+        set argv "--python" $VIRTUALFISH_DEFAULT_PYTHON (string escape -- $argv)
     end
     set -lx PIP_USER 0
-    eval (realpath $VIRTUALFISH_PYTHON_EXEC) -m virtualenv $argv $VIRTUALFISH_HOME/$envname
+    eval (realpath $VIRTUALFISH_PYTHON_EXEC) -m virtualenv (string escape -- $argv) (realpath $VIRTUALFISH_HOME/$envname)
     set vestatus $status
     if begin; [ $vestatus -eq 0 ]; and [ -d $VIRTUALFISH_HOME/$envname ]; end
         vf activate $envname
@@ -199,7 +199,7 @@ end
 
 function __vf_tmp --description "Create a virtualenv that will be removed when deactivated"
     set -l env_name (printf "%s%.4x" "tempenv-" (random) (random) (random))
-    vf new $argv $env_name
+    vf new (string escape -n -- $argv) $env_name
     set -g VF_TEMPORARY_ENV
 end
 


### PR DESCRIPTION
* This pull request adds some conditional logic for people who are, like me, using MSYS2 + fish on windows and attempting to use virtualfish
* There are some small changes where code execution on all platforms is affected (quoting when sourcing on load, using `string escape` for `argv` when passing into `virtualenv` for example
* The primary goal is to have no changes at all for people using virtualfish currently, but to add usability for users on windows attempting to use virtualfish but encountering bugs related to hardcoded paths to /bin, /bin/python, and unescaped inputs which can't handle spaces in directory paths on windows