### PR TITLE
Avoid using cd unnecessarily

### DIFF
--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -303,9 +303,8 @@ end
 
 function __vf_globalpackages --description "Toggle global site packages"
   if set -q VIRTUAL_ENV
-      vf cd
       # use site-packages/.. to avoid ending up in python-wheels
-      cd lib/python*/site-packages/..
+      pushd $VIRTUAL_ENV/lib/python*/site-packages/..
       if test -e $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
         echo "Enabling global site packages"
         rm $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
@@ -313,6 +312,7 @@ function __vf_globalpackages --description "Toggle global site packages"
         echo "Disabling global site packages"
         touch $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
       end
+      popd
     else
         echo "No virtualenv is active."
     end

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -183,8 +183,11 @@ function __vf_cd --description "Change directory to this virtualenv"
 end
 
 function __vf_cdpackages --description "Change to the site-packages directory of this virtualenv"
-    vf cd
-    cd (find . -name site-packages -type d | head -n1)
+    if set -q VIRTUAL_ENV
+        cd (find $VIRTUAL_ENV -name site-packages -type d | head -n1)
+    else
+        echo "No virtualenv is active."
+    end
 end
 
 function __vf_tmp --description "Create a virtualenv that will be removed when deactivated"


### PR DESCRIPTION
Using multiple `cd` calls means one cannot use `cd -` to return to the previous directory. (#95)

`vf globalpackages` isn't supposed to change directory, so it should use `pushd`/`popd` instead (#108)