### PR TITLE
Improve compat aliases deactivate

### DIFF
--- a/virtualfish/compat_aliases.fish
+++ b/virtualfish/compat_aliases.fish
@@ -3,10 +3,11 @@ function workon
         vf ls
     else
         vf activate $argv[1]
+        function deactivate
+            vf deactivate
+            functions -e deactivate
+        end
     end
-end
-function deactivate
-    vf deactivate
 end
 function mktmpenv
     vf tmp $argv


### PR DESCRIPTION
Move definition of the deactivate function inside workon, so it is only defined when using a virtual environment. Then when deactivate is called, it removes itself from the session.