### PR TITLE
Fix TypeError in Fish REPL test run() function

### DIFF
--- a/virtualfish/test/repl.py
+++ b/virtualfish/test/repl.py
@@ -103,8 +103,8 @@ class Fish:
         status = int(q_until_null(self.stdout_q).decode('utf8'))
 
         if status not in expected_exit_codes:
-            sys.stdout.write(output)
-            sys.stderr.write(error)
+            sys.stdout.write(str(output))
+            sys.stderr.write(str(error))
             raise ValueError("Expected command to exit with {}, got {}".format(
                 expected_exit_codes, status
             ))


### PR DESCRIPTION
I noticed that running the tests currently results in a test failure due to a TypeError in the REPL test code's `run()` function:
```
TypeError: write() argument must be str, not bytes
```
I don't know whether it is an appropriate fix, but I resolved the error by converting the output bytes to strings.