### PR TITLE
Update minimum PyTest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(
     ],
     extras_require={
         'dev': [
-            'pytest>=3.1.3,<3.2',
-            'pytest-xdist>=1.22.2,<1.23',
+            'pytest>=3.6,<6',
+            'pytest-xdist>=1.22.2,<2',
         ],
     },
     entry_points={


### PR DESCRIPTION
Otherwise results in:
```
AttributeError: 'Function' object has no attribute 'get_closest_marker'
```
See also: https://github.com/pytest-dev/pytest-asyncio/issues/115