### PR TITLE
feat(new): Parse args, support Pyenv & much more

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,8 +4,8 @@ Installation and Setup
 Installing
 ----------
 
-1. Make sure you are running Fish 3.x. If you are running an Ubuntu LTS
-   release that has an older Fish version, install Fish 3.x via the
+1. Make sure you are running Fish 3.1+. If you are running an Ubuntu LTS
+   release that has an older Fish version, install Fish via the
    `Fish 3.x release series PPA`_.
 2. Install VirtualFish by running: ``pip install virtualfish``
 3. Install the VirtualFish loader by running:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -45,6 +45,21 @@ the most reliable option, but if the target Python executable is on your
 
     vf new -p pypy my_pypy_env
 
+Sometimes there may be Python interpreters on your system that are not on your
+``PATH``, with full filesystem paths that are long and thus hard to remember and
+type. VirtualFish makes dealing with these easier by automatically detecting and
+using Python interpreters in a few known situations, in the following order:
+
+1. Homebrew_ keg-only versioned Python executable (e.g., 3.8) found at:
+   ``/usr/local/opt/python@3.8/bin/python3.8``
+2. asdf_ Python plugin is installed and has built the specified Python version.
+3. Pyenv_ is installed and has built the specified Python version.
+4. Pythonz_ is installed and has built the specified Python version.
+
+In these latter cases, in addition to passing flags such as ``-p python3.8`` or
+``-p python3.9.0a4``, you can even get away with specifying just the version
+numbers, such as ``-p 3.8`` or ``-p 3.9.0a4``.
+
 Configuration Variables
 -----------------------
 
@@ -68,3 +83,7 @@ you want those changes to take effect for the current shell session.
 
 .. _virtualenvwrapper: https://bitbucket.org/dhellmann/virtualenvwrapper
 .. _Virtualenv: https://virtualenv.pypa.io/en/latest/
+.. _Homebrew: https://docs.brew.sh/Homebrew-and-Python
+.. _asdf: https://asdf-vm.com/
+.. _Pyenv: https://github.com/pyenv/pyenv
+.. _Pythonz: https://github.com/saghul/pythonz

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,8 +4,7 @@ Usage
 Commands
 --------
 
--  ``vf new [<options>] <envname>`` - Create a virtual environment. Note that
-   ``<envname>`` should be specified **last**.
+-  ``vf new [<options>] <envname>`` - Create a virtual environment.
 -  ``vf ls`` - List the available virtual environments.
 -  ``vf activate <envname>`` - Activate a virtual environment. (Note: Doesn’t
    use the ``activate.fish`` script provided by Virtualenv_.)

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -121,6 +121,46 @@ function __vf_deactivate --description "Deactivate this virtualenv"
     set -e VIRTUAL_ENV
 end
 
+function __vfsupport_find_python --description "Search for and return Python path"
+    set -l python
+    set -l python_arg $argv[1]
+    set -l py_version (string replace "python" "" $python_arg)
+    set -l brew_path "/usr/local/opt/python@$py_version/bin/python$py_version"
+    # Executable on PATH (python3/python3.8) or full interpreter path
+    if set -l py_path (command -s $python_arg)
+        set python "$py_path"
+    # Version number in Homebrew keg-only versioned Python formula
+    else if test -x "$brew_path"
+        set python "$brew_path"
+    # Use `asdf` Python plugin, if found and provided version is available
+    else if type -q "asdf"
+        set -l asdf_plugins (asdf plugin list)
+        if contains python $asdf_plugins
+            set -l asdf_path (asdf where python $py_version)/bin/python
+            if test -x "$asdf_path"
+                set python "$asdf_path"
+            end
+        end
+    # Use Pyenv, if found and provided version is available
+    else if type -q "pyenv"
+        set -l pyenv_path (pyenv which python$py_version)
+        if test -x "$pyenv_path"
+            set python "$pyenv_path"
+        end
+    # Use Pythonz, if found and provided version is available
+    else if type -q "pythonz"
+        set -l pythonz_path (pythonz locate $py_version)
+        if test -x "$pythonz_path"
+            set python "$pythonz_path"
+        end
+    end
+    # If no interpreter was found, pass to Virtualenv as-is
+    if not test -x "$python"
+        set python $python_arg
+    end
+    echo $python
+end
+
 function __vf_new --description "Create a new virtualenv"
 
     # Deactivate the current virtualenv, if one is active
@@ -132,9 +172,6 @@ function __vf_new --description "Create a new virtualenv"
     argparse -n "vf new" -x q,v,d --ignore-unknown "h/help" "q/quiet" "v/verbose" "d/debug" "p/python=" -- $argv
     set envname $argv[-1]
     set -e argv[-1]
-    if set -q VIRTUALFISH_DEFAULT_PYTHON
-        set argv "--python" $VIRTUALFISH_DEFAULT_PYTHON $argv
-    end
 
     if set -q _flag_help
         set -l normal (set_color normal)
@@ -150,6 +187,22 @@ function __vf_new --description "Create a new virtualenv"
         echo "To see available "(set_color blue)"Virtualenv"$normal" option flags, run: "$green"virtualenv --help"$normal
         return 0
     end
+
+    # Use Python interpreter if provided; otherwise fall back to sane default
+    if set -q _flag_python
+        set python (__vfsupport_find_python $_flag_python)
+    else if set -q VIRTUALFISH_DEFAULT_PYTHON
+        set python $VIRTUALFISH_DEFAULT_PYTHON
+    else if set -q VIRTUALFISH_PYTHON_EXEC
+        set python $VIRTUALFISH_PYTHON_EXEC
+    else
+        set python python
+    end
+
+    if set -q python
+        set argv "--python" $python $argv
+    end
+
     set -lx PIP_USER 0
     eval $VIRTUALFISH_PYTHON_EXEC -m virtualenv $argv $VIRTUALFISH_HOME/$envname
     set vestatus $status

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -129,10 +129,26 @@ function __vf_new --description "Create a new virtualenv"
     end
 
     emit virtualenv_will_create
+    argparse -n "vf new" -x q,v,d --ignore-unknown "h/help" "q/quiet" "v/verbose" "d/debug" "p/python=" -- $argv
     set envname $argv[-1]
     set -e argv[-1]
     if set -q VIRTUALFISH_DEFAULT_PYTHON
         set argv "--python" $VIRTUALFISH_DEFAULT_PYTHON $argv
+    end
+
+    if set -q _flag_help
+        set -l normal (set_color normal)
+        set -l green (set_color green)
+        echo "Purpose: Creates a new virtual environment"
+        echo "Usage: "$green"vf new "(set_color -di)"[-p <python-version>] [-q | -v | -d] [-h] [<virtualenv-flags>]"$normal$green" <virtualenv-name>"$normal
+        echo
+        echo "Examples:"
+        echo
+        echo $green"vf new -p /usr/local/bin/python3 yourproject"$normal
+        echo $green"vf new -p python3.8 --system-site-packages yourproject"$normal
+        echo
+        echo "To see available "(set_color blue)"Virtualenv"$normal" option flags, run: "$green"virtualenv --help"$normal
+        return 0
     end
     set -lx PIP_USER 0
     eval $VIRTUALFISH_PYTHON_EXEC -m virtualenv $argv $VIRTUALFISH_HOME/$envname

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -237,6 +237,22 @@ function __vf_new --description "Create a new virtualenv"
         set virtualenv_args "--python" $python $virtualenv_args
     end
 
+    # Virtualenv outputs too much, so we use its quiet mode by default.
+    # "--verbose" yields its normal output; "--debug" yields its verbose output
+    if not set -q _flag_quiet
+        echo "Creating "(set_color blue)"$envname"(set_color normal)" via "(set_color green)"$python"(set_color normal)" …"
+    end
+    if set -q _flag_debug
+        echo "Virtualenv args: $virtualenv_args"
+        echo "Other args: $envname"
+        echo "Invoking: $VIRTUALFISH_PYTHON_EXEC -m virtualenv $VIRTUALFISH_HOME/$envname $virtualenv_args"
+        set virtualenv_args "--verbose" $virtualenv_args
+    else if set -q _flag_verbose
+        set virtualenv_args $virtualenv_args
+    else
+        set virtualenv_args "--quiet" $virtualenv_args
+    end
+
     # Use Virtualenv to create the new environment
     set -lx PIP_USER 0
     eval $VIRTUALFISH_PYTHON_EXEC -m virtualenv $VIRTUALFISH_HOME/$envname $virtualenv_args


### PR DESCRIPTION
This adds argument parsing to the `vf new` command (#71) via Fish's [`argparse` function](https://fishshell.com/docs/current/cmds/argparse.html), which I then subsequently used to provide the following enhancements:

* Find & use non-PATH Python interpreters via common paths/tools (Pyenv, Pythonz, etc.) (#114)
* Virtual environment name no longer needs to be passed as last argument (#16)
* Control output verbosity via `--quiet`, `--verbose`, & `--debug` flags
* Add help via `vf new --help` option flag (#146)