### PR TITLE
Fix `vf addpath` Python 3 compatibility bug

### DIFF
--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -333,7 +333,7 @@ end
 
 function __vf_addpath --description "Adds a path to sys.path in this virtualenv"
     if set -q VIRTUAL_ENV
-        set -l site_packages (eval "$VIRTUAL_ENV/bin/python -c 'import distutils; print(distutils.sysconfig.get_python_lib())'")
+        set -l site_packages (eval "$VIRTUAL_ENV/bin/python -c 'import distutils.sysconfig; print(distutils.sysconfig.get_python_lib())'")
         set -l path_file $site_packages/_virtualenv_path_extensions.pth
 
         set -l remove 0


### PR DESCRIPTION
When I run `vf addpath`, I get the error:
```
AttributeError: module 'distutils' has no attribute 'sysconfig'
```

This is a simple fix for that error. I am running
```
Python 3.7.7 (default, Mar 10 2020, 15:43:33)
[Clang 11.0.0 (clang-1100.0.33.17)] on darwin
```

I also tested this on
```
Python 2.7.16 (default, Dec 13 2019, 18:00:32)
[GCC 4.2.1 Compatible Apple LLVM 11.0.0 (clang-1100.0.32.4) (-macos10.15-objc-s on darwin
```