### PR TITLE
rm: Allow deleting multiple virtualenvs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Allow deleting multiple virtualenvs with single invocations of `vf rm <name>...`

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -282,20 +282,22 @@ function __vf_new --description "Create a new virtualenv"
     end
 end
 
-function __vf_rm --description "Delete a virtualenv"
-    if not [ (count $argv) -eq 1 ]
-        echo "You need to specify exactly one virtualenv."
+function __vf_rm --description "Delete virtualenvs"
+    if [ (count $argv) -lt 1 ]
+        echo "You need to specify at least one virtualenv."
         return 1
     end
-    if begin; set -q VIRTUAL_ENV; and [ $argv[1] = (basename $VIRTUAL_ENV) ]; end
-        echo "You can't delete a virtualenv you're currently using."
-        return 1
-    end
-    echo "Removing $VIRTUALFISH_HOME/$argv[1]"
-    if command -q trash
-        command trash $VIRTUALFISH_HOME/$argv[1]
-    else
-        command rm -rf $VIRTUALFISH_HOME/$argv[1]
+    for venv in $argv
+        if begin; set -q VIRTUAL_ENV; and [ $venv = (basename $VIRTUAL_ENV) ]; end
+            echo "virtualenv \"$venv\" can't be deleted as you're currently using it."
+            return 1
+        end
+        echo "Removing $VIRTUALFISH_HOME/$venv"
+        if command -q trash
+            command trash $VIRTUALFISH_HOME/$venv
+        else
+            command rm -rf $VIRTUALFISH_HOME/$venv
+        end
     end
 end
 


### PR DESCRIPTION
Currently, `vf rm` only accepts 1 argument, which is a bit annoying when I'm trying to clean up multiple leftover virtualenvs.

Support multiple arguments for convenience.