### PR TITLE
Use PyXDG from freedesktop.org rather than xdg from srstevenson.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ python = "^3.6"
 pkgconfig = "^1.5"
 psutil = "^5.7"
 virtualenv = "^20"
-xdg = "^4.0"
+pyxdg = "^0.26"
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"

--- a/virtualfish/loader/installer.py
+++ b/virtualfish/loader/installer.py
@@ -1,10 +1,11 @@
 import os
 import sys
 
-from xdg import XDG_CONFIG_HOME
+import xdg.BaseDirectory
 
 from virtualfish.loader import load
 
+XDG_CONFIG_HOME = xdg.BaseDirectory.xdg_config_home
 INSTALL_DIR = os.path.join(XDG_CONFIG_HOME, "fish", "conf.d")
 INSTALL_FILE = os.path.join(INSTALL_DIR, "virtualfish-loader.fish")
 


### PR DESCRIPTION
The motivation for this is really just to make virtualfish easier to package on Arch Linux, since Arch installs PyXDG as xdg. There was also a suggestion on the bug tracker that PyXDG would be the better option to use anyway, but I don't have enough background to judge that myself.

See:
https://freedesktop.org/wiki/Software/pyxdg/
https://aur.archlinux.org/packages/virtualfish/
https://bugs.archlinux.org/task/64173