### PR TITLE
Require minimum Fish shell version when installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ VirtualFish is currently maintained by [Justin Mayer](https://justinmayer.com/),
 
 ## A quickstart, for the impatient
 
+👉 **Fish version 3.1 or higher is required.** 👈
+
 1. `pip install virtualfish`
 2. `vf install`
 3. [Add VirtualFish to your prompt](https://virtualfish.readthedocs.org/en/latest/install.html#customizing-your-fish-prompt)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+* Ensure minimum required Fish shell version is present when installing
+* Prevent error on older Fish shell versions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
+packaging = "^20.3"
 pkgconfig = "^1.5"
 psutil = "^5.7"
 virtualenv = "^20"

--- a/virtualfish/loader/cli.py
+++ b/virtualfish/loader/cli.py
@@ -4,6 +4,9 @@ import psutil
 from virtualfish.loader import installer
 
 
+minimum_fish_version = "3.1"
+
+
 def install():
     if "--help" in argv or "-h" in argv:
         print("Usage: vf install [<plugin> ...]")
@@ -11,7 +14,25 @@ def install():
     installer.install(argv[2:])
 
 
+def check_fish_version():
+    """Exit and notify if minimum Fish version is not installed. Bail silently if
+       'packaging' module is missing or if Fish is not installed."""
+    try:
+        import subprocess
+        from packaging import version
+
+        cmd = ["fish", "-c", "echo $version"]
+        fish_version = subprocess.check_output(cmd).decode("utf-8").strip()
+        if version.parse(fish_version) < version.parse(minimum_fish_version):
+            print("VirtualFish requires Fish {} or higher. Current version: {}".format(
+                minimum_fish_version, fish_version))
+            exit()
+    except (ModuleNotFoundError, FileNotFoundError):
+        pass
+
+
 def main():
+    check_fish_version()
     if len(argv) >= 2 and argv[1] == "install":
         install()
         print(
@@ -31,7 +52,8 @@ def main():
                 "load it."
             )
         else:
-            print("VirtualFish isn't compatible with {}, only Fish.".format(the_shell))
+            print("VirtualFish isn't compatible with {}, only Fish {}+.".format(
+                the_shell, minimum_fish_version))
 
 
 if __name__ == "__main__":

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -302,11 +302,11 @@ function __vf_rm --description "Delete one or more virtual environments"
 end
 
 function __vf_ls --description "List all available virtual environments"
-    pushd $VIRTUALFISH_HOME && set -e dirprev[-1]
+    begin; pushd $VIRTUALFISH_HOME; and set -e dirprev[-1]; end
     for i in */bin/python
         echo $i
     end | sed "s|/bin/python||"
-    popd && set -e dirprev[-1]
+    begin; popd; and set -e dirprev[-1]; end
 end
 
 function __vf_cd --description "Change directory to this virtualenv"


### PR DESCRIPTION
Certain VirtualFish functionality depends on newer Fish shell features. Users on older Fish versions who don't notice the minimum version requirement may subsequently encounter errors.

For example, "&&" is not supported on older Fish versions, so this includes a commit that switches to more-verbose but more-compatible syntax. Other parts of VirtualFish still require Fish 3.1+, but this bit was causing errors any time `virtualfish.fish` was sourced.

This also adds a prominent minimum Fish version notice to the README. This information was already available in the **Installing** docs, but some folks did not see that.

Most notably, this adds a `check_fish_version()` function to the initial Python-based installation process that exits and notifies if the minimum Fish shell version requirement is not met.

Closes #169 #170