### PR TITLE
Fix global packages

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,6 +15,7 @@ Commands
 -  ``vf cd`` - Change directory to currently-activated virtual environment.
 -  ``vf cdpackages`` - Change directory to currently-active virtual
    environment’s site-packages.
+-  ``vf globalpackages`` - Toggle system site packages.
 -  ``vf addpath`` - Add a directory to this virtual environment’s ``sys.path``.
 -  ``vf all <command>`` - Run a command in all virtual environments sequentially.
 -  ``vf connect`` - Connect the current working directory with the currently

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -450,10 +450,9 @@ function __vf_globalpackages --description "Toggle global site packages"
     if set -q VIRTUAL_ENV
 	pushd $VIRTUAL_ENV
 
-	# if pyvenv.cfg is present, toggle configuration value therein
-	# (https://www.python.org/dev/peps/pep-0405/#isolation-from-system-site-packages)
-	#
-	# otherwise use legacy no-global-site-package.txt file in lib/python*
+	# If pyvenv.cfg is present, toggle configuration value therein.
+	# <https://www.python.org/dev/peps/pep-0405/#isolation-from-system-site-packages>
+	# Otherwise use legacy no-global-site-package.txt file in lib/python*/
 
 	if test -e $VIRTUALFISH_VENV_CONFIG_FILE  # PEP 405
 	    # toggle

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -480,9 +480,9 @@ function __vf_globalpackages --description "Toggle global site packages"
 	end
 
 	if [ $enabled -eq 0 ]
-	    echo "Enabling global site packages"
+	    echo "Global site packages enabled"
 	else
-	    echo "Disabling global site packages"
+	    echo "Global site packages disabled"
 	end
 
 	popd

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -445,6 +445,8 @@ function __vf_help --description "Print VirtualFish usage information"
 end
 
 function __vf_globalpackages --description "Toggle global site packages"
+    set -l enabled
+
     if set -q VIRTUAL_ENV
 	pushd $VIRTUAL_ENV
 

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -456,10 +456,12 @@ function __vf_globalpackages --description "Toggle global site packages"
 
 	if test -e $VIRTUALFISH_VENV_CONFIG_FILE  # PEP 405
 	    # toggle
-	    sed -i '/include-system-site-packages/ {s/true/false/;t;s/false/true/}' $VIRTUALFISH_VENV_CONFIG_FILE
+	    command sed -i '/include-system-site-packages/ {s/true/false/;t;s/false/true/}' \
+		$VIRTUALFISH_VENV_CONFIG_FILE
 
 	    # read new state
-	    if [ "true" = (sed -n 's/include-system-site-packages\s=\s\(true\|false\)/\1/p' $VIRTUALFISH_VENV_CONFIG_FILE) ]
+	    if [ "true" = (command sed -n 's/include-system-site-packages\s=\s\(true\|false\)/\1/p' \
+		$VIRTUALFISH_VENV_CONFIG_FILE) ]
 		set enabled 0
 	    else
 		set enabled 1

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -448,46 +448,46 @@ function __vf_globalpackages --description "Toggle global site packages"
     set -l enabled
 
     if set -q VIRTUAL_ENV
-	pushd $VIRTUAL_ENV
+        pushd $VIRTUAL_ENV
 
-	# If pyvenv.cfg is present, toggle configuration value therein.
-	# <https://www.python.org/dev/peps/pep-0405/#isolation-from-system-site-packages>
-	# Otherwise use legacy no-global-site-package.txt file in lib/python*/
+        # If pyvenv.cfg is present, toggle configuration value therein.
+        # <https://www.python.org/dev/peps/pep-0405/#isolation-from-system-site-packages>
+        # Otherwise use legacy no-global-site-package.txt file in lib/python*/
 
-	if test -e $VIRTUALFISH_VENV_CONFIG_FILE  # PEP 405
-	    # toggle
-	    command sed -i '/include-system-site-packages/ {s/true/false/;t;s/false/true/}' \
-		$VIRTUALFISH_VENV_CONFIG_FILE
+        if test -e $VIRTUALFISH_VENV_CONFIG_FILE  # PEP 405
+            # toggle
+            command sed -i '/include-system-site-packages/ {s/true/false/;t;s/false/true/}' \
+                $VIRTUALFISH_VENV_CONFIG_FILE
 
-	    # read new state
-	    if [ "true" = (command sed -n 's/include-system-site-packages\s=\s\(true\|false\)/\1/p' \
-		$VIRTUALFISH_VENV_CONFIG_FILE) ]
-		set enabled 0
-	    else
-		set enabled 1
-	    end
-	else  # legacy
-	    # use site-packages/.. to avoid ending up in python-wheels
-	    pushd $VIRTUAL_ENV/lib/python*/site-packages/..
-	    if test -e $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
-		command rm $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
-		set enabled 0
-	    else
-		touch $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
-		set enabled 1
-	    end
-	    popd
-	end
+            # read new state
+            if [ "true" = (command sed -n 's/include-system-site-packages\s=\s\(true\|false\)/\1/p' \
+                $VIRTUALFISH_VENV_CONFIG_FILE) ]
+                set enabled 0
+            else
+                set enabled 1
+            end
+        else  # legacy
+            # use site-packages/.. to avoid ending up in python-wheels
+            pushd $VIRTUAL_ENV/lib/python*/site-packages/..
+            if test -e $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
+                command rm $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
+                set enabled 0
+            else
+                touch $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
+                set enabled 1
+            end
+            popd
+        end
 
-	if [ $enabled -eq 0 ]
-	    echo "Global site packages enabled"
-	else
-	    echo "Global site packages disabled"
-	end
+        if [ $enabled -eq 0 ]
+            echo "Global site packages enabled"
+        else
+            echo "Global site packages disabled"
+        end
 
-	popd
+        popd
     else
-	echo "No virtualenv is active."
+        echo "No virtualenv is active."
     end
 end
 

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -485,6 +485,8 @@ function __vf_globalpackages --description "Toggle global site packages"
 	end
 
 	popd
+    else
+	echo "No virtualenv is active."
     end
 end
 

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -409,6 +409,9 @@ if not set -q VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
     set -g VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE "no-global-site-packages.txt"
 end
 
+if not set -q VIRTUALFISH_VENV_CONFIG_FILE
+    set -g VIRTUALFISH_VENV_CONFIG_FILE "pyvenv.cfg"
+end
 
 function __vf_connect --description "Connect this virtualenv to the current directory"
     if set -q VIRTUAL_ENV
@@ -442,19 +445,44 @@ function __vf_help --description "Print VirtualFish usage information"
 end
 
 function __vf_globalpackages --description "Toggle global site packages"
-  if set -q VIRTUAL_ENV
-      # use site-packages/.. to avoid ending up in python-wheels
-      pushd $VIRTUAL_ENV/lib/python*/site-packages/..
-      if test -e $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
-        echo "Enabling global site packages"
-        command rm $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
-      else
-        echo "Disabling global site packages"
-        touch $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
-      end
-      popd
-    else
-        echo "No virtualenv is active."
+    if set -q VIRTUAL_ENV
+	pushd $VIRTUAL_ENV
+
+	# if pyvenv.cfg is present, toggle configuration value therein
+	# (https://www.python.org/dev/peps/pep-0405/#isolation-from-system-site-packages)
+	#
+	# otherwise use legacy no-global-site-package.txt file in lib/python*
+
+	if test -e $VIRTUALFISH_VENV_CONFIG_FILE  # PEP 405
+	    # toggle
+	    sed -i '/include-system-site-packages/ {s/true/false/;t;s/false/true/}' $VIRTUALFISH_VENV_CONFIG_FILE
+
+	    # read new state
+	    if [ "true" = (sed -n 's/include-system-site-packages\s=\s\(true\|false\)/\1/p' $VIRTUALFISH_VENV_CONFIG_FILE) ]
+		set enabled 0
+	    else
+		set enabled 1
+	    end
+	else  # legacy
+	    # use site-packages/.. to avoid ending up in python-wheels
+	    pushd $VIRTUAL_ENV/lib/python*/site-packages/..
+	    if test -e $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
+		command rm $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
+		set enabled 0
+	    else
+		touch $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
+		set enabled 1
+	    end
+	    popd
+	end
+
+	if [ $enabled -eq 0 ]
+	    echo "Enabling global site packages"
+	else
+	    echo "Disabling global site packages"
+	end
+
+	popd
     end
 end
 


### PR DESCRIPTION
Fixes #172.

  - I happily replace the `sed` calls by a single one if someone points at a more elegant solution
  - _toggling_ matches the `virtualenvwrapper` command but I would find it more intuitive to have to commands for _setting_ the inclusion of system site packages. This would however be breaking.

Comments most welcome.