### PR TITLE
Make the auto activation and projects plugin play nice together

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -136,6 +136,9 @@ directory.
 
     If you are using both the *Compatibility Aliases* and *Projects* plugins,
     ``workon`` will alias ``vf workon`` instead of ``vf activate``.
+    If you are using both the *Auto-activation* and *Projects* plugins, the
+    project's virtual environment will be deactivated automatically when you
+    leave the project's directory.
 
 
 Commands

--- a/virtualfish/projects.fish
+++ b/virtualfish/projects.fish
@@ -11,11 +11,6 @@ function __vf_workon --description "Work on a project"
         echo "You must specify a project or virtual environment."
         return 1
     end
-    # Check if auto activation plugin is used alongside projects plugin.
-    # If it is, set VF_AUTO_ACTIVATED flag when switching into project directory
-    if type -q __vfsupport_auto_activate
-        set -l sourced_auto_activation
-    end
     # Matches a virtualenv name and possibly a project name
     if [ -d $VIRTUALFISH_HOME/$argv[1] ]
         vf activate $argv[1]
@@ -23,18 +18,12 @@ function __vf_workon --description "Work on a project"
             set -l project_file_path (command cat $VIRTUAL_ENV/.project)
             if [ -d $project_file_path ]
                 cd $project_file_path
-                if test -z "$sourced_auto_activation"
-                    set -g VF_AUTO_ACTIVATED
-                end
             else
                 echo ".project file path does not exist: $project_file_path"
                 return 2
             end
         else if [ -d $PROJECT_HOME/$argv[1] ]
             cd $PROJECT_HOME/$argv[1]
-            if test -z "$sourced_auto_activation"
-                set -g VF_AUTO_ACTIVATED
-            end
         end
     # Matches a project name but not a virtualenv name
     else if [ -d $PROJECT_HOME/$argv[1] ]
@@ -42,9 +31,6 @@ function __vf_workon --description "Work on a project"
         set -l venv_file "$PROJECT_HOME/$project_name/$VIRTUALFISH_ACTIVATION_FILE"
         if [ -f $venv_file ]
             vf activate (command cat $venv_file)
-            if test -z "$sourced_auto_activation"
-                set -g VF_AUTO_ACTIVATED
-            end
         else
             echo "No virtual environment found."
         end

--- a/virtualfish/projects.fish
+++ b/virtualfish/projects.fish
@@ -11,6 +11,11 @@ function __vf_workon --description "Work on a project"
         echo "You must specify a project or virtual environment."
         return 1
     end
+    # Check if auto activation plugin is used alongside projects plugin.
+    # If it is, set VF_AUTO_ACTIVATED flag when switching into project directory
+    if type -q __vfsupport_auto_activate
+        set -l sourced_auto_activation
+    end
     # Matches a virtualenv name and possibly a project name
     if [ -d $VIRTUALFISH_HOME/$argv[1] ]
         vf activate $argv[1]
@@ -18,12 +23,18 @@ function __vf_workon --description "Work on a project"
             set -l project_file_path (command cat $VIRTUAL_ENV/.project)
             if [ -d $project_file_path ]
                 cd $project_file_path
+                if test -z "$sourced_auto_activation"
+                    set -g VF_AUTO_ACTIVATED
+                end
             else
                 echo ".project file path does not exist: $project_file_path"
                 return 2
             end
         else if [ -d $PROJECT_HOME/$argv[1] ]
             cd $PROJECT_HOME/$argv[1]
+            if test -z "$sourced_auto_activation"
+                set -g VF_AUTO_ACTIVATED
+            end
         end
     # Matches a project name but not a virtualenv name
     else if [ -d $PROJECT_HOME/$argv[1] ]
@@ -31,6 +42,9 @@ function __vf_workon --description "Work on a project"
         set -l venv_file "$PROJECT_HOME/$project_name/$VIRTUALFISH_ACTIVATION_FILE"
         if [ -f $venv_file ]
             vf activate (command cat $venv_file)
+            if test -z "$sourced_auto_activation"
+                set -g VF_AUTO_ACTIVATED
+            end
         else
             echo "No virtual environment found."
         end


### PR DESCRIPTION
The goal of this PR is to ensure that projects activated with `vf workon` are deactivated again when leaving the project's directory in cases where both the projects and the auto-activation plugins are used.

- Activating a venv and switching directory using `vf workon` now sets VF_AUTO_ACTIVATED flag if auto activation plugin is sourced
- In the auto activation plugin, check if projects plugin is sourced. If so, check if PWD is a project directory to make sure changing into project subdirectories does not deactivate venv if no activation file is present

I'm not exactly an expert in Fish and wasn't sure what's the best way to check if another plugin has been sourced. I just check if a particular function from the projects or auto-activation plugin is available using `type -q`, but please advice if there is a better way to do this