### PR TITLE
Add addplugins and rmplugins commands 

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -4,10 +4,18 @@ Plugins
 VirtualFish comes with a number of built-in plugins.
 
 You can use them by passing their names as arguments to the ``vf install``
-command. For example, the following will activate the ``compat_aliases``,
+command at first installation. For example, the following will activate the ``compat_aliases``,
 ``projects``, and ``environment`` plugins::
 
     vf install compat_aliases projects environment
+
+To add or remove plugins after installation use the ``vf addplugins`` and
+``vf rmplugins`` commands. For example, the following will activate the
+``auto_activation`` and ``projects`` plugins, and the next commands will remove
+the ``projects`` plugin::
+
+    vf addplugins auto_activation projects
+    vf rmplugins projects
 
 .. _compat_aliases:
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -4,15 +4,15 @@ Plugins
 VirtualFish comes with a number of built-in plugins.
 
 You can use them by passing their names as arguments to the ``vf install``
-command at first installation. For example, the following will activate the ``compat_aliases``,
-``projects``, and ``environment`` plugins::
+command when installing for the first time. For example, the following will
+activate the ``compat_aliases``, ``projects``, and ``environment`` plugins::
 
     vf install compat_aliases projects environment
 
-To add or remove plugins after installation use the ``vf addplugins`` and
+To add or remove plugins after installation, use the ``vf addplugins`` and
 ``vf rmplugins`` commands. For example, the following will activate the
-``auto_activation`` and ``projects`` plugins, and the next commands will remove
-the ``projects`` plugin::
+``auto_activation`` and ``projects`` plugins, and the subsequent command
+will remove the ``projects`` plugin::
 
     vf addplugins auto_activation projects
     vf rmplugins projects

--- a/virtualfish/loader/__init__.py
+++ b/virtualfish/loader/__init__.py
@@ -4,18 +4,21 @@ import sys
 import pkg_resources
 
 
-def load(plugins=()):
+def load(plugins=(), full_install=True):
     try:
         version = pkg_resources.get_distribution("virtualfish").version
         commands = ["set -g VIRTUALFISH_VERSION {}".format(version)]
     except pkg_resources.DistributionNotFound:
         commands = []
-
     base_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    commands += [
-        "set -g VIRTUALFISH_PYTHON_EXEC {}".format(sys.executable),
-        "source {}".format(os.path.join(base_path, "virtual.fish")),
-    ]
+
+    if full_install:
+        commands += [
+            "set -g VIRTUALFISH_PYTHON_EXEC {}".format(sys.executable),
+            "source {}".format(os.path.join(base_path, "virtual.fish")),
+        ]
+    else:
+        commands = []
 
     for plugin in plugins:
         path = os.path.join(base_path, plugin + ".fish")
@@ -24,5 +27,7 @@ def load(plugins=()):
         else:
             raise ValueError("Plugin does not exist: " + plugin)
 
-    commands.append("emit virtualfish_did_setup_plugins")
+    if full_install:
+        commands.append("emit virtualfish_did_setup_plugins")
+
     return commands

--- a/virtualfish/loader/installer.py
+++ b/virtualfish/loader/installer.py
@@ -22,5 +22,37 @@ def uninstall():
     os.unlink(INSTALL_FILE)
 
 
-if __name__ == "__main__" and sys.argv[1] == "uninstall":
-    uninstall()
+def addplugins(plugins=()):
+    with open(INSTALL_FILE, 'r') as fp:
+        conf = fp.readlines()
+        position = -1
+        for i, line in enumerate(conf):
+            if "virtual.fish" in line:
+                position = i
+                continue
+            for j, plugin in enumerate(plugins):
+                if plugin+".fish" in line:
+                    plugins.pop(j)
+        for i, p in enumerate(load(plugins, full_install=False)):
+            conf.insert(position+1+i, p+'\n')
+    with open(INSTALL_FILE, 'w') as fp:
+        fp.writelines(conf)
+
+def rmplugins(plugins=()):
+    with open(INSTALL_FILE, 'r') as fp:
+        conf = fp.readlines()
+        position = -1
+        for i, line in enumerate(conf):
+            for j, plugin in enumerate(plugins):
+                if plugin+".fish" in line:
+                    conf.pop(i)
+    with open(INSTALL_FILE, 'w') as fp:
+        fp.writelines(conf)
+
+if __name__ == "__main__":
+    if sys.argv[1] == "uninstall":
+        uninstall()
+    elif sys.argv[1] == "addplugins":
+        addplugins(sys.argv[2:])
+    elif sys.argv[1] == "rmplugins":
+        rmplugins(sys.argv[2:])

--- a/virtualfish/loader/installer.py
+++ b/virtualfish/loader/installer.py
@@ -38,6 +38,7 @@ def addplugins(plugins=()):
     with open(INSTALL_FILE, 'w') as fp:
         fp.writelines(conf)
 
+
 def rmplugins(plugins=()):
     with open(INSTALL_FILE, 'r') as fp:
         conf = fp.readlines()

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -491,7 +491,7 @@ function __vfsupport_setup_autocomplete --on-event virtualfish_did_setup_plugins
 end
 
 function __vf_install --description "Install VirtualFish"
-    echo "VirtualFish is already installed! Hooray! For trying to install extra plugins use the addplugins command"
+    echo "VirtualFish is already installed! Hooray! To install extra plugins, use the addplugins command."
     return 0
 end
 

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -530,6 +530,5 @@ function __vf_rmplugins --description "Remove one or more plugins"
         return -1
     end
     set -l python (__vfsupport_get_default_python)
-    echo $python
     $python -m virtualfish.loader.installer rmplugins $argv
 end

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -33,6 +33,7 @@ function vf --description "VirtualFish: fish plugin to manage virtualenvs"
     if test (count $argv) -gt 1
         set scargs $argv[2..-1]
     end
+
     if functions -q $funcname
         eval $funcname $scargs
     else

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -5,6 +5,18 @@ if not set -q VIRTUALFISH_HOME
     set -g VIRTUALFISH_HOME $HOME/.virtualenvs
 end
 
+function __vfsupport_get_default_python --description "Return Python interpreter defined in variables, if any"
+    set -l python
+    if set -q VIRTUALFISH_PYTHON_EXEC
+        set python $VIRTUALFISH_PYTHON_EXEC
+    else if set -q VIRTUALFISH_DEFAULT_PYTHON
+        set python $VIRTUALFISH_DEFAULT_PYTHON
+    else
+        set python python
+    end
+    echo $python
+end
+
 function vf --description "VirtualFish: fish plugin to manage virtualenvs"
     # Check for existence of $VIRTUALFISH_HOME
     if not test -d $VIRTUALFISH_HOME
@@ -496,14 +508,7 @@ function __vf_install --description "Install VirtualFish"
 end
 
 function __vf_uninstall --description "Uninstall VirtualFish"
-    set -l python
-    if set -q VIRTUALFISH_PYTHON_EXEC
-        set python $VIRTUALFISH_PYTHON_EXEC
-    else if set -q VIRTUALFISH_DEFAULT_PYTHON
-        set python $VIRTUALFISH_DEFAULT_PYTHON
-    else
-        set python python
-    end
+    set -l python (__vfsupport_get_default_python)
     $python -m virtualfish.loader.installer uninstall
     echo "VirtualFish has been uninstalled from this shell."
     echo "Run 'exec fish' to reload Fish."
@@ -515,14 +520,7 @@ function __vf_addplugins --description "Install one or more plugins"
         echo "Provide a plugin to add"
         return -1
     end
-    set -l python
-    if set -q VIRTUALFISH_PYTHON_EXEC
-        set python $VIRTUALFISH_PYTHON_EXEC
-    else if set -q VIRTUALFISH_DEFAULT_PYTHON
-        set python $VIRTUALFISH_DEFAULT_PYTHON
-    else
-        set python python
-    end
+    set -l python (__vfsupport_get_default_python)
     $python -m virtualfish.loader.installer addplugins $argv
 end
 
@@ -531,15 +529,7 @@ function __vf_rmplugins --description "Remove one or more plugins"
         echo "Provide a plugin to remove"
         return -1
     end
-    set -l python
-    if set -q VIRTUALFISH_PYTHON_EXEC
-        set python $VIRTUALFISH_PYTHON_EXEC
-    else if set -q VIRTUALFISH_DEFAULT_PYTHON
-        set python $VIRTUALFISH_DEFAULT_PYTHON
-    else
-        set python python
-    end
+    set -l python (__vfsupport_get_default_python)
+    echo $python
     $python -m virtualfish.loader.installer rmplugins $argv
 end
-
-

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -33,7 +33,6 @@ function vf --description "VirtualFish: fish plugin to manage virtualenvs"
     if test (count $argv) -gt 1
         set scargs $argv[2..-1]
     end
-
     if functions -q $funcname
         eval $funcname $scargs
     else
@@ -491,7 +490,8 @@ function __vfsupport_setup_autocomplete --on-event virtualfish_did_setup_plugins
 end
 
 function __vf_install --description "Install VirtualFish"
-    echo "VirtualFish is already installed! Hooray!"
+    echo "VirtualFish is already installed! Hooray! For trying to install extra plugins use the addplugins command"
+    return 0
 end
 
 function __vf_uninstall --description "Uninstall VirtualFish"
@@ -508,3 +508,37 @@ function __vf_uninstall --description "Uninstall VirtualFish"
     echo "Run 'exec fish' to reload Fish."
     echo "Note that the Python package will still be installed and needs to be removed separately (e.g. using 'pip uninstall virtualfish')."
 end
+
+function __vf_addplugins --description "Install one or more plugins"
+    if test (count $argv) -lt 1
+        echo "Provide a plugin to add"
+        return -1
+    end
+    set -l python
+    if set -q VIRTUALFISH_PYTHON_EXEC
+        set python $VIRTUALFISH_PYTHON_EXEC
+    else if set -q VIRTUALFISH_DEFAULT_PYTHON
+        set python $VIRTUALFISH_DEFAULT_PYTHON
+    else
+        set python python
+    end
+    $python -m virtualfish.loader.installer addplugins $argv
+end
+
+function __vf_rmplugins --description "Remove one or more plugins"
+    if test (count $argv) -lt 1
+        echo "Provide a plugin to remove"
+        return -1
+    end
+    set -l python
+    if set -q VIRTUALFISH_PYTHON_EXEC
+        set python $VIRTUALFISH_PYTHON_EXEC
+    else if set -q VIRTUALFISH_DEFAULT_PYTHON
+        set python $VIRTUALFISH_DEFAULT_PYTHON
+    else
+        set python python
+    end
+    $python -m virtualfish.loader.installer rmplugins $argv
+end
+
+


### PR DESCRIPTION
This pull request creates `addplugins` and `rmplugins` commands to add and remove plugins to an existing installation. I've also added some words to the documentation to make it clearer when to use which command. Alternatively I can refactor this so that `vf install plugin` works even when `vf` is installed and can add the rmplugin functionality to `vf uninstall` let me know if you prefer that and I will change.

This should clear up some confusion and fixes #162.