### PR TITLE
Add `vf upgrade` to fix outdated/broken environments

### DIFF
--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -53,5 +53,9 @@ The full list of events is:
 -  ``virtualenv_will_create``
 -  ``virtualenv_did_create``
 -  ``virtualenv_did_create:<env name>``
+-  ``virtualenv_will_upgrade``
+-  ``virtualenv_will_upgrade:<env name>``
+-  ``virtualenv_did_upgrade``
+-  ``virtualenv_did_upgrade:<env name>``
 -  ``virtualenv_did_connect``
 -  ``virtualenv_did_connect:<env name>``

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -218,6 +218,12 @@ Commands
 Update Python (``update_python``)
 ---------------------------------
 
+.. note::
+
+    The functionality provided by this plugin has been superseded by the
+    ``vf upgrade`` command. This plugin has therefore been deprecated and will
+    likely be removed in the future.
+
 This plugin adds commands to change the Python interpreter of the current
 virtual environment.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,6 +9,7 @@ Commands
 -  ``vf activate <envname>`` - Activate a virtual environment. (Note: Doesn’t
    use the ``activate.fish`` script provided by Virtualenv_.)
 -  ``vf deactivate`` - Deactivate the current virtual environment.
+-  ``vf upgrade [<options>] [<envname(s)>]`` - Upgrade virtual environment(s).
 -  ``vf rm <envname>`` - Delete a virtual environment.
 -  ``vf tmp [<options>]`` - Create a temporary virtual environment with a
    randomly generated name that will be removed when it is deactivated.
@@ -61,6 +62,58 @@ For asdf_, Pyenv_, and Pythonz_ , in addition to passing option flags such as
 just the version numbers, such as ``-p 3.8`` or ``-p 3.9.0a4``.
 
 .. _configuration_variables:
+
+Upgrading Virtual Environments
+------------------------------
+
+Virtual environments contain links to Python interpreters that can become
+outdated over time. In addition, sometimes the underlying Python interpreter
+can be removed by Python upgrades, putting the virtual environment into an
+unusable state. Thankfully, VirtualFish includes a mechanism for upgrading
+outdated/broken environments.
+
+To understand which environments might be outdated/broken, run::
+
+    vf ls --details
+
+VirtualFish compares environment Python versions to the current default Python
+version, as specified by the ``VIRTUALFISH_DEFAULT_PYTHON`` variable (see
+below), if defined. To perform a minor (point-release) upgrade to the
+currently-active virtual environment, run::
+
+    vf upgrade
+
+Minor point-release upgrades will modify in-place the virtual environment’s
+Python version number and symlinks. (While this should work correctly in the
+majority of cases, there is the possibility that future changes to virtual
+environment structure will interfere with this in-place upgrade.)
+
+For major version upgrades, say from Python 3.8.x to 3.9.x, you must instead
+re-build the environment via::
+
+    vf upgrade --rebuild
+
+Re-building an environment will record its current package versions, remove the
+old environment, create a new environment with the same name, and re-install the
+list of recorded package versions.
+
+If VirtualFish determines that a virtual environment is in a broken state, it
+will re-build that environment, even if ``--rebuild`` is omitted.
+
+To upgrade to a specific Python interpreter or version, use the ``--python``
+option::
+
+    vf upgrade --rebuild --python /usr/local/bin/python3.8
+
+Virtual environments need not be active in order to upgrade them. To upgrade
+one or more virtual environments, specify their names::
+
+    vf upgrade project1 project2
+
+Upgrades can also be applied to all environments. To re-build all existing
+environments::
+
+    vf upgrade --rebuild --all
 
 Configuration Variables
 -----------------------

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -476,6 +476,120 @@ function __vf_connect --description "Connect this virtualenv to the current dire
     end
 end
 
+function __vf_upgrade --description "Upgrade virtualenv(s) to newer Python version"
+    argparse -n "vf upgrade" "h/help" "p/python=" "r/rebuild" "a/all" -- $argv
+    set -l python
+    set -l venv_list
+    set -l normal (set_color normal)
+    set -l green (set_color green)
+
+    if set -q _flag_help
+        echo
+        echo "Purpose: Upgrades existing virtual environment(s)"
+        echo "Usage: "$green"vf upgrade "(set_color -di)"[--rebuild] [--python <path/version>] [--all] <env name(s)>"$normal
+        echo
+        echo "Examples:"
+        echo
+        echo (set_color -di)"# Upgrade active virtual environment to current default Python version"$normal
+        echo $green"vf upgrade"$normal
+        echo (set_color -di)"# Rebuild env1 & env2 using Python 3.8.5 via asdf, pyenv, or Pythonz"$normal
+        echo $green"vf upgrade --rebuild --python 3.8.5 env1 env2"$normal\n
+        return 0
+    end
+
+    # Use Python interpreter if provided; otherwise fall back to sane default
+    if set -q _flag_python
+        set python (__vfsupport_find_python $_flag_python)
+    else
+        set python (__vfsupport_get_default_python)
+    end
+    __vfsupport_check_python $python
+    if test $status -ne 0
+        echo "Specified (or default) Python interpreter does appear to be valid."
+        return -1
+    end
+    # Set envs to upgrade: all, a list of virtualenvs, or current environment
+    if set -q _flag_all
+        set venv_list (vf ls)
+    else if test (count $argv) -gt 0
+        set venv_list $argv
+    else if set -q VIRTUAL_ENV
+        set venv_list (basename $VIRTUAL_ENV)
+    else
+        echo "No environment activated or specified."
+        return 1
+    end
+    for venv in $venv_list
+        set -l packages
+        set -l venv_path "$VIRTUALFISH_HOME/$venv"
+
+        emit virtualenv_will_upgrade
+        emit virtualenv_will_upgrade:$venv
+
+        __vfsupport_check_python --pip "$venv_path/bin/python"
+        if test $status -ne 0
+            echo (set_color red)"$venv is broken. Rebuilding…"(set_color normal)
+            for p in $venv_path/lib/python3.*/site-packages/*.dist-info
+                set packages $packages (string replace "-" "==" (string replace ".dist-info" "" (basename $p)))
+            end
+        end
+        # Re-build if (1) --rebuild passed or (2) above check yields broken env
+        if begin; set -q _flag_rebuild; or test -n "$packages"; end
+            set -l install_cmd
+            # Install via poetry.lock if found; otherwise Pip-install packages
+            if begin; set -q PROJECT_HOME; and test -f "$PROJECT_HOME/$venv/poetry.lock"; end
+                set install_cmd "poetry install"
+            else
+                # If broken env, use above package list. Otherwise use `pip freeze`.
+                if test -z "$packages"
+                    set packages ($venv_path/bin/pip freeze)
+                end
+                set install_cmd "if test -n '$packages'; pip install -U $packages; end"
+            end
+            if set -q VIRTUAL_ENV
+                vf deactivate
+            end
+            vf rm $venv
+            and vf new -p $python $venv
+            and eval $install_cmd
+        else
+            # Minor upgrade, so modify existing env's symlinks & version numbers
+            # Get full version numbers for both old and new Python interpreters
+            set -l old_py_fv ($venv_path/bin/python -V | string split " ")[2]
+            set -l new_py_fv ($python -V | string split " ")[2]
+            # Get and compare *major* version numbers (e.g., 3.8, 3.9)
+            set -l old_py_sv (string split . $old_py_fv)
+            set -l new_py_sv (string split . $new_py_fv)
+            set -l old_py_mv "$old_py_sv[1].$old_py_sv[2]"
+            set -l new_py_mv "$new_py_sv[1].$new_py_sv[2]"
+            # If major version numbers don't match, exit without upgrading
+            if test "$old_py_mv" -ne "$new_py_mv"
+                echo "Not upgrading $venv ($old_py_fv) to $new_py_fv. Add '--rebuild' for major version upgrades."
+            else
+                # Update symlinks & version numbers
+                echo "Upgrading $venv from $old_py_fv to $new_py_fv"
+                command rm "$venv_path/bin/python"
+                    and command ln -s "$python$new_py_mv" "$venv_path/bin/python"
+                command rm "$venv_path/bin/python3"
+                    and command ln -s "$python$new_py_mv" "$venv_path/bin/python3"
+                command rm "$venv_path/bin/python$old_py_mv"
+                    and command ln -s "$python$new_py_mv" "$venv_path/bin/python$new_py_mv"
+                if test -f "$venv_path/pyvenv.cfg"
+                    command sed -i '' -e "s/$old_py_fv/$new_py_fv/g" "$venv_path/pyvenv.cfg"
+                end
+                # Clear caches
+                command find "$venv_path" -name "__pycache__" -type d -print0|xargs -0 rm -r --
+                if begin; set -q PROJECT_HOME; and test -d "$PROJECT_HOME/$venv"; end
+                    command find "$PROJECT_HOME/$venv" -name "__pycache__" -type d -print0|xargs -0 rm -r --
+                    command find "$PROJECT_HOME/$venv" -name ".pytest_cache" -type d -print0|xargs -0 rm -r --
+                end
+            end
+        end
+        emit virtualenv_did_upgrade
+        emit virtualenv_did_upgrade:$venv
+    end
+end
+
 function __vf_help --description "Print VirtualFish usage information"
     echo "VirtualFish $VIRTUALFISH_VERSION"
     echo


### PR DESCRIPTION
Replacing the now-deprecated `update_python` plugin, the new `vf upgrade` command can both perform in-place virtual environment upgrades as well as re-build environments from scratch, even when environment Python/Pip executables are inoperable.

See documentation within for more details. Closes #141