### PR TITLE
globalpackages: add enable/disable/toggle subcommands, add help

### DIFF
--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -625,44 +625,107 @@ function __vf_help --description "Print VirtualFish usage information"
     echo "For full documentation, see: $help_url"
 end
 
-function __vf_globalpackages --description "Toggle global site packages"
-    set -l enabled
+function __vf_globalpackages --description "Manage global site packages"
+    argparse --stop-nonopt --ignore-unknown --name "vf globalpackages" "h/help" -- $argv
+    if set -q _flag_help
+	    set -l normal (set_color normal)
+	    set -l green (set_color green)
+	    echo
+	    echo "Manage global site packages."
+	    echo
+	    echo "Usage: "$green"vf globalpackages [<action>] [--quiet/-q]"$normal
+	    echo
+	    echo "Available actions: "$green"enable"$normal", "$green"disable"$normal", "$green"toggle"$normal" (default)"
+	    return 0
+    end
+
     if set -q VIRTUAL_ENV
-        pushd $VIRTUAL_ENV
-        # If pyvenv.cfg is present, toggle configuration value therein.
-        # <https://www.python.org/dev/peps/pep-0405/#isolation-from-system-site-packages>
-        # Otherwise use legacy no-global-site-package.txt file in lib/python*/
-        if test -e $VIRTUALFISH_VENV_CONFIG_FILE  # PEP 405
-            # toggle
-            command sed -i '/include-system-site-packages/ {s/true/false/;t;s/false/true/}' \
-                $VIRTUALFISH_VENV_CONFIG_FILE
-            # read new state
-            if [ "true" = (command sed -n 's/include-system-site-packages\s=\s\(true\|false\)/\1/p' \
-                $VIRTUALFISH_VENV_CONFIG_FILE) ]
-                set enabled 0
-            else
-                set enabled 1
-            end
-        else  # legacy
-            # use site-packages/.. to avoid ending up in python-wheels
-            pushd $VIRTUAL_ENV/lib/python*/site-packages/..
-            if test -e $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
-                command rm $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
-                set enabled 0
-            else
-                touch $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
-                set enabled 1
-            end
-            popd
-        end
-        if [ $enabled -eq 0 ]
-            echo "Global site packages enabled"
-        else
-            echo "Global site packages disabled"
-        end
-        popd
+	    set -l action $argv[1]
+	    set -l action_args
+
+	    if begin; test (count $argv) -eq 0; or string match -qr '^\-' -- $argv[1]; end
+	        # no action passed, default to toggle
+	        set action "toggle"
+	        set action_args $argv[1..-1]
+	    else
+	        set action_args $argv[2..-1]
+	    end
+
+	    set -l funcname "__vfsupport_globalpackages_$action"
+
+	    if functions -q $funcname
+	        eval $funcname $action_args
+	    else
+	        echo "Invalid action: $action."
+	        return 1
+	    end
     else
-        echo "Cannot toggle global site packages without an active virtual environment."
+	    echo "No active virtual environment."
+	    return 1
+    end
+end
+
+function __vfsupport_globalpackages_enable --description "Enable global site packages"
+    argparse -n "vf globalpackages enable" "q/quiet" -- $argv
+    pushd $VIRTUAL_ENV
+    if test -e $VIRTUALFISH_VENV_CONFIG_FILE  # PEP 405
+	    command sed -i '/include-system-site-packages/ s/\(true\|false\)/true/' $VIRTUALFISH_VENV_CONFIG_FILE
+    else  # legacy
+	    # use site-packages/.. to avoid ending up in python-wheels
+	    pushd $VIRTUAL_ENV/lib/python*/site-packages/..
+	    touch $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
+	    popd
+    end
+    popd
+
+    if not set -q _flag_quiet
+	    echo "Global site packages enabled."
+    end
+end
+
+function __vfsupport_globalpackages_disable --description "Disable global site packages"
+    argparse -n "vf globalpackages disable" "q/quiet" -- $argv
+    pushd $VIRTUAL_ENV
+    if test -e $VIRTUALFISH_VENV_CONFIG_FILE  # PEP 405
+	    command sed -i '/include-system-site-packages/ s/\(true\|false\)/false/' $VIRTUALFISH_VENV_CONFIG_FILE
+    else  # legacy
+	    # use site-packages/.. to avoid ending up in python-wheels
+	    pushd $VIRTUAL_ENV/lib/python*/site-packages/..
+	    command rm -f $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
+	    popd
+    end
+    popd
+
+    if not set -q _flag_quiet
+	    echo "Global site packages disabled."
+    end
+end
+
+function __vfsupport_globalpackages_toggle --description "Toggle global site packages"
+    pushd $VIRTUAL_ENV
+    set -l globalpkgs_enabled
+    if test -e $VIRTUALFISH_VENV_CONFIG_FILE  # PEP 405
+	    if [ "true" = (command sed -n 's/include-system-site-packages\s=\s\(true\|false\)/\1/p' $VIRTUALFISH_VENV_CONFIG_FILE) ]
+	        set globalpkgs_enabled 0
+	    else
+	        set globalpkgs_enabled 1
+	    end
+    else  # legacy
+	    # use site-packages/.. to avoid ending up in python-wheels
+	    pushd $VIRTUAL_ENV/lib/python*/site-packages/..
+	    if test -e $VIRTUALFISH_GLOBAL_SITE_PACKAGES_FILE
+	        set globalpkgs_enabled 0
+	    else
+	        set globalpkgs_enabled 1
+	    end
+	    popd
+    end
+    popd
+
+    if test $globalpkgs_enabled -eq 0
+	    __vfsupport_globalpackages_disable $argv
+    else
+	    __vfsupport_globalpackages_enable $argv
     end
 end
 


### PR DESCRIPTION
Hello!

This patch implements explicit actions for `vf globalpackages` as discussed in #181. The old behavior (toggle) is preserved when calling with no explicit action. I also added a `-q/--quiet` switch to remove the new state display. Finally, reworking this was the opportunity to add a help message, following the incentive in #105.

New usage:
  
- `vf globalpackages [-q]`: toggle use of system site packages
- `vf globalpackages toggle [-q]`: same as above
- `vf globalpackages enable [-q]`: enable system site packages
- `vf globalpackages disable [-q]`: disable system site packages

The command returns 0 up success.

Comments most welcome. Thanks!