### PR TITLE
Add eclm Oh My Fish theme to "See also" page

### DIFF
--- a/docs/seealso.rst
+++ b/docs/seealso.rst
@@ -8,7 +8,7 @@ project, and it’s not on this list, please submit a pull request.
 Prompts
 -------
 
-- Both ``bobthefish`` and ``scorphish`` themes for `Oh My Fish!`_
+- ``bobthefish``, ``scorphish`` and ``eclm`` themes for `Oh My Fish!`_
   support VirtualFish.
 
 .. _Oh My Fish!: https://github.com/oh-my-fish/oh-my-fish


### PR DESCRIPTION
Hi : ) Thanks for creating and maintaining VirtualFish!

I just [opened a pull request adding VirtualFIsh support to `eclm` theme](https://github.com/oh-my-fish/theme-eclm/pull/4) and, **if** it gets merged, I think we could list them in the _See also_ page in the docs. What do you think?

(Leaving this as _Draft_ as it depends on that other PR — I will remove the _Draft_ status if that is the case.)