### PR TITLE
auto_activation: Auto-activate only for interactive sessions

### DIFF
--- a/virtualfish/auto_activation.fish
+++ b/virtualfish/auto_activation.fish
@@ -2,6 +2,10 @@
 # Automatic activation
 
 function __vfsupport_auto_activate --on-variable PWD
+    if not status --is-interactive
+        return
+    end
+
     if status --is-command-substitution
         return
     end


### PR DESCRIPTION
I had some issues when creating Fish scripts that occasionally `cd` to venv-connected directories.

This fix should make auto-activation work only when the shell is actually interactive.