### PR TITLE
feat(connect): Auto-activate virtualenv if specified

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+* `vf connect`: Now accepts an (optional) virtualenv argument to connect (and activate)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-* `vf connect`: Now accepts an (optional) virtualenv argument to connect (and activate)
+* `vf connect`: Accept an (optional) virtualenv name argument to connect (and activate)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -19,10 +19,10 @@ Commands
 -  ``vf globalpackages`` - Toggle system site packages.
 -  ``vf addpath`` - Add a directory to this virtual environment’s ``sys.path``.
 -  ``vf all <command>`` - Run a command in all virtual environments sequentially.
--  ``vf connect`` - Connect the current working directory with the currently
-   active virtual environment. This requires the :ref:`auto-activation plugin
-   <auto_activation>` to be enabled in order to have any effect besides creating
-   a :file:`.venv` file in the current directory.
+-  ``vf connect [<envname>]`` - Connect the current working directory with the
+   currently active (or specified) virtual environment. This requires the
+   :ref:`auto-activation plugin <auto_activation>` to be enabled in order to
+   have any effect besides creating a :file:`.venv` file in the current directory.
 
 If you are accustomed to virtualenvwrapper_ commands (``workon``, etc.), you may
 wish to enable the :ref:`compat_aliases` plugin.

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -474,7 +474,7 @@ function __vf_connect --description "Connect this virtualenv to the current dire
     set -l red (set_color red)
 
     if test (count $argv) -gt 1
-        echo "Usage: "$green"vf connect [<env name>]"$normal
+        echo "Usage: "$green"vf connect [<envname>]"$normal
         return 1
     end
 

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -469,12 +469,24 @@ if not set -q VIRTUALFISH_VENV_CONFIG_FILE
 end
 
 function __vf_connect --description "Connect this virtualenv to the current directory"
+    set -l normal (set_color normal)
+    set -l green (set_color green)
+    set -l red (set_color red)
+
+    if test (count $argv) -gt 1
+        echo "Usage: "$green"vf connect [<env name>]"$normal
+        return 1
+    end
+
+    test (count $argv) -eq 0; or vf activate $argv[1]
+
     if set -q VIRTUAL_ENV
         basename $VIRTUAL_ENV > $VIRTUALFISH_ACTIVATION_FILE
         emit virtualenv_did_connect
         emit virtualenv_did_connect:(basename $VIRTUAL_ENV)
     else
-        echo "No virtualenv is active."
+        echo $red"Cannot connect without an active virtual environment."$normal
+        return 1
     end
 end
 
@@ -758,6 +770,7 @@ function __vfsupport_setup_autocomplete --on-event virtualfish_did_setup_plugins
     end
 
     complete -x -c vf -n '__vfcompletion_using_command activate' -a "(vf ls)"
+    complete -x -c vf -n '__vfcompletion_using_command connect' -a "(vf ls)"
     complete -x -c vf -n '__vfcompletion_using_command rm' -a "(vf ls)"
 end
 


### PR DESCRIPTION
Introduce an optional `<env name>` argument to `vf connect` which auto-activates the virtualenv in question, if it exists.
