### PR TITLE
Preserve .project file when doing vf upgrade --rebuild

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -145,7 +145,8 @@ directory.
 .. note::
 
 
-    If you are using both the *Compatibility Aliases* and *Projects* plugins,
+    .project files are restored when calling `vf upgrade --rebuild`. If you
+    are using both the *Compatibility Aliases* and *Projects* plugins,
     ``workon`` will alias ``vf workon`` instead of ``vf activate``.
     If you are using both the *Auto-activation* and *Projects* plugins, the
     project's virtual environment will be deactivated automatically when you

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -145,8 +145,8 @@ directory.
 .. note::
 
 
-    .project files are restored when calling `vf upgrade --rebuild`. If you
-    are using both the *Compatibility Aliases* and *Projects* plugins,
+    ``.project`` files are restored when calling ``vf upgrade --rebuild``.
+    If you are using both the *Compatibility Aliases* and *Projects* plugins,
     ``workon`` will alias ``vf workon`` instead of ``vf activate``.
     If you are using both the *Auto-activation* and *Projects* plugins, the
     project's virtual environment will be deactivated automatically when you

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -538,6 +538,7 @@ function __vf_upgrade --description "Upgrade virtualenv(s) to newer Python versi
         # Re-build if (1) --rebuild passed or (2) above check yields broken env
         if begin; set -q _flag_rebuild; or test -n "$packages"; end
             set -l install_cmd
+            set -l project_file_path
             # Install via poetry.lock if found; otherwise Pip-install packages
             if begin; set -q PROJECT_HOME; and test -f "$PROJECT_HOME/$venv/poetry.lock"; end
                 set install_cmd "poetry install"
@@ -558,7 +559,7 @@ function __vf_upgrade --description "Upgrade virtualenv(s) to newer Python versi
             vf rm $venv
             and vf new -p $python $venv
             and eval $install_cmd
-            if set -q project_file_path
+            if set -q project_file_path[1]
                 echo $project_file_path > $venv_path/.project
             end
         else

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -551,9 +551,16 @@ function __vf_upgrade --description "Upgrade virtualenv(s) to newer Python versi
             if set -q VIRTUAL_ENV
                 vf deactivate
             end
+            # Check if venv contains .project file and save its contents before removing
+            if test -e $venv_path/.project
+                set project_file_path (cat $venv_path/.project)
+            end
             vf rm $venv
             and vf new -p $python $venv
             and eval $install_cmd
+            if set -q project_file_path
+                echo $project_file_path > $venv_path/.project
+            end
         else
             # Minor upgrade, so modify existing env's symlinks & version numbers
             # Get full version numbers for both old and new Python interpreters

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -552,13 +552,14 @@ function __vf_upgrade --description "Upgrade virtualenv(s) to newer Python versi
             if set -q VIRTUAL_ENV
                 vf deactivate
             end
-            # Check if venv contains .project file and save its contents before removing
+            # If environment contains a .project file, save its contents before removing
             if test -e $venv_path/.project
                 set project_file_path (cat $venv_path/.project)
             end
             vf rm $venv
             and vf new -p $python $venv
             and eval $install_cmd
+            # If environment contained a .project file, restore its contents
             if set -q project_file_path[1]
                 echo $project_file_path > $venv_path/.project
             end

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -538,7 +538,7 @@ function __vf_upgrade --description "Upgrade virtualenv(s) to newer Python versi
         # Re-build if (1) --rebuild passed or (2) above check yields broken env
         if begin; set -q _flag_rebuild; or test -n "$packages"; end
             set -l install_cmd
-            set -l project_file_path
+            set -l linked_project
             # Install via poetry.lock if found; otherwise Pip-install packages
             if begin; set -q PROJECT_HOME; and test -f "$PROJECT_HOME/$venv/poetry.lock"; end
                 set install_cmd "poetry install"
@@ -554,14 +554,14 @@ function __vf_upgrade --description "Upgrade virtualenv(s) to newer Python versi
             end
             # If environment contains a .project file, save its contents before removing
             if test -e $venv_path/.project
-                set project_file_path (cat $venv_path/.project)
+                set linked_project (cat $venv_path/.project)
             end
             vf rm $venv
             and vf new -p $python $venv
             and eval $install_cmd
             # If environment contained a .project file, restore its contents
             if set -q project_file_path[1]
-                echo $project_file_path > $venv_path/.project
+                echo $linked_project > $venv_path/.project
             end
         else
             # Minor upgrade, so modify existing env's symlinks & version numbers


### PR DESCRIPTION
Currently, if my venv `project-venv` contains a `.project` file, this file is not recreated when I call `vf upgrade --rebuild project-venv`. I think it is reasonable to expect the 'rebuild' command to restore this file.