### PR TITLE
Fix Pyenv version detection

### DIFF
--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -149,7 +149,12 @@ function __vfsupport_find_python --description "Search for and return Python pat
         end
     # Use Pyenv, if found and provided version is available
     else if type -q "pyenv"
-        set -l pyenv_path (pyenv which python$py_version)
+        if test -n "$PYENV_ROOT"
+            set pyenv_path "$PYENV_ROOT"/versions/"$py_version"/bin/python
+        else
+            # If $PYENV_ROOT hasn't been set, assume versions are stored in ~/.pyenv
+            set pyenv_path "$HOME"/.pyenv/versions/"$py_version"/bin/python
+        end
         if command -q "$pyenv_path"
             set python "$pyenv_path"
         end


### PR DESCRIPTION
Hopefully this fixes #203.

To test if a Python version is available via Pyenv (e.g. when calling `vf new -p 3.8.10 my_venv`), VirtualFish called `pyenv which python$py_version`. However, `pyenv which python3.8.10` fails (at least in the most recent version of Pyenv) and `pyenv which python 3.8.10` seems to ignore the provided version and always prints the path of whatever Python version is currently active in Pyenv.

This fix instead checks for `$PYENV_ROOT/versions/$py_version/bin/python` OR `$HOME/.pyenv/versions/$py_version/bin/python` (if $PYENV_ROOT not set, which might for example be the case when Pyenv was installed with Homebrew). With these changes, specifying versions with just the number works again:

```fish
> pyenv versions
  system
  3.8.10
* 3.9.5 (set by /Users/cecep/.pyenv/version)
> mkvirtualenv -p 3.8.10 test_pyenv3810
Creating test_pyenv3810 via ~/.pyenv/versions/3.8.10/bin/python …
test_pyenv3810 (3.8.10) > mkvirtualenv -p 3.9.5 test_pyenv395
Creating test_pyenv395 via ~/.pyenv/versions/3.9.5/bin/python …
test_pyenv395 (3.9.5) >
```