### PR TITLE
Don't auto-deactivate venv if it's not a project

### DIFF
--- a/virtualfish/auto_activation.fish
+++ b/virtualfish/auto_activation.fish
@@ -50,9 +50,12 @@ function __vfsupport_auto_activate --on-variable PWD
     # Projects stored in $PROJECT_HOME typically don't have .project files. To accommodate users
     # that keep all their projects in $PROJECT_HOME, deactivate virtualenv if it wasn't
     # auto-activated, doesn't contain .project file and $PWD is not a sudirectory of $PROJECT_HOME
-    else if begin set -q VIRTUAL_ENV; and not set -q VF_AUTO_ACTIVATED project_path; end
-        if begin not string match -qr -- "$PROJECT_HOME" "$PWD"; or test "$PROJECT_HOME" = "$PWD"; end
-            vf deactivate
+    else if begin set -q VIRTUAL_ENV; and not set -q VF_AUTO_ACTIVATED; and not set -q project_path; end
+        # Make sure current VIRTUAL_ENV is a project
+        if contains (basename $VIRTUAL_ENV) (vf lsprojects)
+            if begin not string match -qr -- "$PROJECT_HOME" "$PWD"; or test "$PROJECT_HOME" = "$PWD"; end
+                vf deactivate
+            end
         end
     else
         # if there's an auto-activated virtualenv, deactivate it


### PR DESCRIPTION
Uff, I just realized that #209 introduced a rather unfortunate bug: when I just want to activate a venv that is not connected to any project or has an activation file ( `vf activate testvenv`), #209 will immediately deactivate the venv when changing the directory (because it's not in `$PROJECT_HOME`). To fix this, I now also check if $VIRTUAL_ENV is in `vf lsprojects`