### PR TITLE
Use tool versions file to colorize `ls --details`

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -76,6 +76,13 @@ To understand which environments might be outdated/broken, run::
 
     vf ls --details
 
+You can maintain a list of target Python versions via a line such as the
+following in a ``~/.tool-versions`` file::
+
+    python 3.9.7 3.8.12 3.7.11 3.6.14
+
+Environment Python versions that match one of those versions will be shown as
+up-to-date (green). If target Python versions are not specified in that file,
 VirtualFish compares environment Python versions to the current default Python
 version, as specified by the ``VIRTUALFISH_DEFAULT_PYTHON`` variable (see
 below), if defined. To perform a minor (point-release) upgrade to the


### PR DESCRIPTION
Previously, environment Python versions in the list shown by `vf ls --details` were only considered to be up-to-date (i.e., displayed in green) when a given environment's Python version is greater or equal to the default Python version returned by `__vfsupport_get_default_python()`. If you have some environments on older but fully-supported Python versions, those would show up in yellow even though they should be considered up-to-date.

With these changes, given a `~/.tool-versions` file that contains the following line:

    python 3.9.7 3.8.12 3.7.11 3.6.14

… any environment's Python version that matches one of the specified versions will be considered up-to-date and displayed in green.