### PR TITLE
Avoid erroneous warning if venv activated with trailing slash

### DIFF
--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -79,9 +79,10 @@ function __vf_activate --description "Activate a virtualenv"
     end
 
     # Warn if virtual environment name does not appear in prompt
+    set venv_name (basename "$VIRTUAL_ENV")
     if begin; not set -q VIRTUAL_ENV_DISABLE_PROMPT; or test -z "$VIRTUAL_ENV_DISABLE_PROMPT"; end
-        if begin; not set -q fish_right_prompt; or not string match -q -- "*$argv[1]*" (eval fish_right_prompt); end
-            and not string match -q -- "*$argv[1]*" (eval fish_prompt)
+        if begin; not set -q fish_right_prompt; or not string match -q -- "*$venv_name*" (eval fish_right_prompt); end
+            and not string match -q -- "*$venv_name*" (eval fish_prompt)
             echo "Virtual environment activated but not shown in shell prompt. To fix, see:"
             echo "<https://virtualfish.readthedocs.io/en/latest/install.html#customizing-your-fish-prompt>"
         end


### PR DESCRIPTION
Both `vf activate myvenv` and `vf activate myvenv/` successfully activate the venv, 
but the latter causes a warning to be printed to the terminal.

Came across this because at some stage a trailing slash somehow ended up at the end of my activate command.

The trailing slash doesn't cause any issues with activation since the venv's are directories, and trailing slashes do not cause issues with the various functions (`test -d` etc) used in virtualfish when activating a venv, so for the warning message just checking the `basename` should be fine. 