### PR TITLE
Suggest native `vf new` command when venv does not exist

### DIFF
--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -49,7 +49,7 @@ function __vf_activate --description "Activate a virtualenv"
     end
     if not [ -d $VIRTUALFISH_HOME/$argv[1] ]
         echo "The virtualenv $argv[1] does not exist."
-        echo "You can create it with mkvirtualenv."
+        echo "You can create it with `vf new $argv[1]`."
         return 2
     end
 


### PR DESCRIPTION
We should use native virtualfish commands

`mkvirtualenv` is only available through the compat-aliases virtualfish plugin: https://virtualfish.readthedocs.io/en/latest/plugins.html#virtualenvwrapper-compatibility-aliases-compat-aliases