### PR TITLE
Guard call to pip in upgrade function

### DIFF
--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -578,7 +578,9 @@ function __vf_upgrade --description "Upgrade virtualenv(s) to newer Python versi
             else
                 # If broken env, use above package list. Otherwise use `pip freeze`.
                 if test -z "$packages"
-                    set packages ($venv_path/bin/pip freeze)
+                    if command --query "$venv_path/bin/pip"
+                        set packages ($venv_path/bin/pip freeze)
+                    end
                 end
                 set install_cmd "if test -n '$packages'; pip install -U $packages; end"
             end


### PR DESCRIPTION
While upgrading some venvs for Python 3.10, one of them caused virtualfish to spew fish error traces due to `pip` somehow having gone missing. Not sure how it ended up like that (whether it was due to vf or not), but it seems like a good idea to add a check that the command exists before we run it.

