### PR TITLE
Add autocompletions for `vf new -p` and `vf upgrade -p` with asdf or pyenv installs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -61,6 +61,28 @@ For asdf_, Pyenv_, and Pythonz_ , in addition to passing option flags such as
 ``-p python3.8`` or ``-p python3.9.0a4``, you can even get away with specifying
 just the version numbers, such as ``-p 3.8`` or ``-p 3.9.0a4``.
 
+If you would like to get autocompletions for ``vf new -p`` and ``vf upgrade -p``
+with Python versions installed via asdf_ or pyenv_, execute the following
+interactively. For asdf_::
+
+    set -Ux VIRTUALFISH_PYVERSION_COMPLETION "asdf"
+
+For pyenv_::
+
+    set -Ux VIRTUALFISH_PYVERSION_COMPLETION "pyenv"
+
+After reloading your shell (e.g. via ``exec fish``) numbers of Python versions
+installed via asdf_ or pyenv_ will be autocompleted. Because this is using fish's
+`universal variables`_, you only need to execute this once and there is no need
+to add this line to your ``config.fish`` file. However, if you would like these
+autocompletions set up automatically on a new machine, you could add the
+following to your config (adjust by picking either asdf_ or pyenv_)::
+
+    if test -z "$VIRTUALFISH_PYVERSION_COMPLETION"
+        set -Ux VIRTUALFISH_PYVERSION_COMPLETION "asdf"/"pyenv"/"pyorg"
+        exec fish
+    end
+
 .. _configuration_variables:
 
 Upgrading Virtual Environments
@@ -149,3 +171,4 @@ you want those changes to take effect for the current shell session.
 .. _asdf: https://asdf-vm.com/
 .. _Pyenv: https://github.com/pyenv/pyenv
 .. _Pythonz: https://github.com/saghul/pythonz
+.. _universal variables: https://fishshell.com/docs/current/tutorial.html#universal-variables

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -803,6 +803,19 @@ function __vfsupport_setup_autocomplete --on-event virtualfish_did_setup_plugins
     complete -x -c vf -n '__vfcompletion_using_command connect' -a "(vf ls)"
     complete -x -c vf -n '__vfcompletion_using_command rm' -a "(vf ls)"
     complete -x -c vf -n '__vfcompletion_using_command upgrade' -a "(vf ls)"
+    # Optional: Autocomplete `vf new -p` and `vf upgrade -p` with Python versions installed via
+    # asdf or pyenv. To use, interactively execute `set -Ux VIRTUALFISH_PYVERSION_COMPLETION <"asdf"/"pyenv">`
+    # and reload your shell
+    if set -q VIRTUALFISH_PYVERSION_COMPLETION
+        if test $VIRTUALFISH_PYVERSION_COMPLETION = "asdf"
+            complete -x -c vf -n '__vfcompletion_using_command new' -s p -l python -a "(asdf list python 2> /dev/null | sed -e 's/^[[:space:]]*//')"
+            complete -x -c vf -n '__vfcompletion_using_command upgrade' -s p -l python -a "(asdf list python 2> /dev/null | sed -e 's/^[[:space:]]*//')"
+        else if test $VIRTUALFISH_PYVERSION_COMPLETION = "pyenv"
+            complete -x -c vf -n '__vfcompletion_using_command new' -s p -l python -a "(pyenv versions --bare)"
+            complete -x -c vf -n '__vfcompletion_using_command upgrade' -s p -l python -a "(pyenv versions --bare)"
+        end
+    end
+
 end
 
 function __vfsupport_get_default_python --description "Return Python interpreter defined in variables, if any"


### PR DESCRIPTION
This commit adds autocompletions for `vf new -p` and `vf upgrade -p` to list version numbers from Python installations in `asdf` or `pyenv`. Those autocompletions are off by default and can be activated by setting a universal variable named `VIRTUALFISH_PYVERSION_COMPLETION` to either `asdf` or `pyenv`.

Note that this only seems to work with Fish's universal variable, I guess because virtualfish's autocompletions are loaded before `config.fish` is sourced. Also note that turning this on will deactivate autocompletions of files and directories for `vf new -p` and `vf upgrade -p`, but I think it's an acceptable trade-off.