### PR TITLE
Improve detection of installed Python version

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -54,12 +54,16 @@ using Python interpreters in a few known situations, in the following order:
 1. asdf_ Python plugin is installed and has built the specified Python version.
 2. Pyenv_ is installed and has built the specified Python version.
 3. Pythonz_ is installed and has built the specified Python version.
-4. Homebrew_ keg-only versioned Python executable (e.g., 3.8) found at:
-   ``/usr/local/opt/python@3.8/bin/python3.8``
+4. Python.org_ Mac installation of specified Python version (e.g., 3.10) found
+   at: ``/Library/Frameworks/Python.framework/Versions``.
+5. Homebrew_ keg-only versioned Python executable (e.g., 3.8) found at:
+   ``/usr/local/opt/python@3.8/bin/python3.8``.
 
 For asdf_, Pyenv_, and Pythonz_ , in addition to passing option flags such as
 ``-p python3.8`` or ``-p python3.9.0a4``, you can even get away with specifying
-just the version numbers, such as ``-p 3.8`` or ``-p 3.9.0a4``.
+just the version numbers, such as ``-p 3.8`` or ``-p 3.9.0a4``. Python.org_
+versions should be specified with Major.Minor version numbers, such as
+``-p 3.10``.
 
 .. _configuration_variables:
 
@@ -149,3 +153,4 @@ you want those changes to take effect for the current shell session.
 .. _asdf: https://asdf-vm.com/
 .. _Pyenv: https://github.com/pyenv/pyenv
 .. _Pythonz: https://github.com/saghul/pythonz
+.. _Python.org: https://www.python.org/downloads/macos/

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -134,36 +134,38 @@ function __vfsupport_find_python --description "Search for and return Python pat
     set -l python
     set -l python_arg $argv[1]
     set -l py_version (string replace "python" "" $python_arg)
+    set -l pyorg_path "/Library/Frameworks/Python.framework/Versions/$py_version/bin/python$py_version"
     set -l brew_path "/usr/local/opt/python@$py_version/bin/python$py_version"
+    set -l asdf_path
+    if begin; type -q "asdf"; and contains "python" (asdf plugin list); end
+        set asdf_path (asdf where python $py_version)/bin/python
+    end
+    set -l pyenv_path
+    if type -q "pyenv"
+        set pyenv_path (pyenv root)/versions/"$py_version"/bin/python
+    end
+    set -l pythonz_path
+    if type -q "pythonz"
+        set pythonz_path (pythonz locate $py_version)
+    end
+
     # Executable on PATH (python3/python3.8) or full interpreter path
     if set -l py_path (command -s $python_arg)
         set python "$py_path"
     # Use `asdf` Python plugin, if found and provided version is available
-    else if type -q "asdf"
-        set -l asdf_plugins (asdf plugin list)
-        if contains python $asdf_plugins
-            set -l asdf_path (asdf where python $py_version)/bin/python
-            if command -q "$asdf_path"
-                set python "$asdf_path"
-            end
-        end
-    # Use Pyenv, if found and provided version is available
-    else if type -q "pyenv"
-        if test -n "$PYENV_ROOT"
-            set pyenv_path "$PYENV_ROOT"/versions/"$py_version"/bin/python
-        else
-            # If $PYENV_ROOT hasn't been set, assume versions are stored in ~/.pyenv
-            set pyenv_path "$HOME"/.pyenv/versions/"$py_version"/bin/python
-        end
-        if command -q "$pyenv_path"
-            set python "$pyenv_path"
-        end
+    else if command -q "$asdf_path"
+        set python "$asdf_path"
+    # Use pyenv, if found and provided version is available
+    else if command -q "$pyenv_path"
+        set python "$pyenv_path"
     # Use Pythonz, if found and provided version is available
-    else if type -q "pythonz"
-        set -l pythonz_path (pythonz locate $py_version)
-        if command -q "$pythonz_path"
-            set python "$pythonz_path"
-        end
+    else if command -q "$pythonz_path"
+        set python "$pythonz_path"
+    # Use Python versions from the Python.org installer. Note: This only
+    # works when Major.Minor version numbers were provided (e.g. 3.10),
+    # Major.Minor.Micro will fail (e.g. 3.10.3)
+    else if command -q "$pyorg_path"
+        set python "$pyorg_path"
     # Version number in Homebrew keg-only versioned Python formula
     else if command -q "$brew_path"
         set python "$brew_path"


### PR DESCRIPTION
First, this commit adds detection of Python versions installed via [Python.org's Mac OS installers](https://www.python.org/downloads/macos/) (which are installed in `/Library/Frameworks/Python.framework/Versions/`). virtualfish will prefer Python.org installations over Homebrew Python, but `asdf`, `pyenv`, or `pythonz` are preferred over Python.org installs.

Second, this commit fixes an issue in how Python versions are deteced when calling `vf new -p` or `vf upgrade -p`. Before this commit, virtualfish checked if various executables are available, but didn't continue to search if the specified Python version has not been installed with said application. For example, if `pyenv` is available but the specified Python version has not been installed with pyenv, virtualfish will directly fall back to pass to Virtualenv as-is instead of continuing the search in, say, `pythonz` or Homebrew.

While it is unlikely that one would have both `pyenv` and `pythonz` installed, continuing to search for a Python version if it hasn't been installed in the first application found is useful with regards to detecting Python.org installs. One might mostly use `pyenv`, but has issues compiling a particular Python version with it and therefore installs it with Python.org's Mac installer.