### PR TITLE
Autocompletions for Python installs via Pyton.org Mac installer

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -61,6 +61,28 @@ For asdf_, Pyenv_, and Pythonz_ , in addition to passing option flags such as
 ``-p python3.8`` or ``-p python3.9.0a4``, you can even get away with specifying
 just the version numbers, such as ``-p 3.8`` or ``-p 3.9.0a4``.
 
+If you would like to get autocompletions for ``vf new -p`` and ``vf upgrade -p``
+with Python versions installed via asdf_ or pyenv_, execute the following
+interactively. For asdf_::
+
+    set -Ux VIRTUALFISH_PYVERSION_COMPLETION "asdf"
+
+For pyenv_::
+
+    set -Ux VIRTUALFISH_PYVERSION_COMPLETION "pyenv"
+
+After reloading your shell (e.g. via ``exec fish``) numbers of Python versions
+installed via asdf_ or pyenv_ will be autocompleted. Because this is using fish's
+`universal variables`_, you only need to execute this once and there is no need
+to add this line to your ``config.fish`` file. However, if you would like these
+autocompletions set up automatically on a new machine, you could add the
+following to your config (adjust by picking either asdf_ or pyenv_)::
+
+    if test -z "$VIRTUALFISH_PYVERSION_COMPLETION"
+        set -Ux VIRTUALFISH_PYVERSION_COMPLETION "asdf"/"pyenv"/"pyorg"
+        exec fish
+    end
+
 .. _configuration_variables:
 
 Upgrading Virtual Environments
@@ -149,3 +171,4 @@ you want those changes to take effect for the current shell session.
 .. _asdf: https://asdf-vm.com/
 .. _Pyenv: https://github.com/pyenv/pyenv
 .. _Pythonz: https://github.com/saghul/pythonz
+.. _universal variables: https://fishshell.com/docs/current/tutorial.html#universal-variables

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -66,8 +66,8 @@ versions should be specified with Major.Minor version numbers, such as
 ``-p 3.10``.
 
 If you would like to get autocompletions for ``vf new -p`` and ``vf upgrade -p``
-with Python versions installed via asdf_ or pyenv_, execute the following
-interactively. For asdf_::
+with Python versions installed via asdf_, pyenv_, or Python.org_'s Mac installer,
+execute the following interactively. For asdf_::
 
     set -Ux VIRTUALFISH_PYVERSION_COMPLETION "asdf"
 
@@ -75,12 +75,17 @@ For pyenv_::
 
     set -Ux VIRTUALFISH_PYVERSION_COMPLETION "pyenv"
 
+For Python.org_ installations::
+
+    set -Ux VIRTUALFISH_PYVERSION_COMPLETION "pyorg"
+
 After reloading your shell (e.g. via ``exec fish``) numbers of Python versions
-installed via asdf_ or pyenv_ will be autocompleted. Because this is using fish's
-`universal variables`_, you only need to execute this once and there is no need
-to add this line to your ``config.fish`` file. However, if you would like these
-autocompletions set up automatically on a new machine, you could add the
-following to your config (adjust by picking either asdf_ or pyenv_)::
+installed via asdf_, pyenv_, or Python.org_ will be autocompleted. Because this
+is using fish's `universal variables`_, you only need to execute this once and
+there is no need to add this line to your ``config.fish`` file. However, if you
+would like these autocompletions set up automatically on a new machine, you
+could add the following to your config (adjust by picking either asdf_, pyenv_
+or pyorg)::
 
     if test -z "$VIRTUALFISH_PYVERSION_COMPLETION"
         set -Ux VIRTUALFISH_PYVERSION_COMPLETION "asdf"/"pyenv"/"pyorg"

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -803,6 +803,19 @@ function __vfsupport_setup_autocomplete --on-event virtualfish_did_setup_plugins
     complete -x -c vf -n '__vfcompletion_using_command connect' -a "(vf ls)"
     complete -x -c vf -n '__vfcompletion_using_command rm' -a "(vf ls)"
     complete -x -c vf -n '__vfcompletion_using_command upgrade' -a "(vf ls)"
+    # Optional: Autocomplete `vf new -p` and `vf upgrade -p` with Python versions installed via
+    # asdf or pyenv. To use, interactively execute `set -Ux VIRTUALFISH_PYVERSION_COMPLETION <"asdf"/"pyenv">`
+    # and reload your shell
+    if set -q VIRTUALFISH_PYVERSION_COMPLETION
+        if test $VIRTUALFISH_PYVERSION_COMPLETION = "asdf"
+            complete -x -c vf -n '__vfcompletion_using_command new' -s p -l python -a "(asdf list python 2> /dev/null | sed -e 's/^[[:space:]]*//')"
+            complete -x -c vf -n '__vfcompletion_using_command upgrade' -s p -l python -a "(asdf list python 2> /dev/null | sed -e 's/^[[:space:]]*//')"
+        else if test $VIRTUALFISH_PYVERSION_COMPLETION = "pyenv"
+            complete -x -c vf -n '__vfcompletion_using_command new' -s p -l python -a "(pyenv versions --bare)"
+            complete -x -c vf -n '__vfcompletion_using_command upgrade' -s p -l python -a "(pyenv versions --bare)"
+        end
+    end
+
 end
 
 function __vfsupport_get_default_python --description "Return Python interpreter defined in variables, if any"

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -795,6 +795,20 @@ function __vfsupport_setup_autocomplete --on-event virtualfish_did_setup_plugins
         return 1
     end
 
+    function __vfcompletion_pyorg_versions
+        # Optional autocompletions for versions installed with Python.org
+        # Mac installer. Used for `vf new -p` and `vf upgrade -p` if
+        # VIRTUALFISH_PYVERSION_COMPLETION set to 'pyorg'
+        set -l pyorg_dir /Library/Frameworks/Python.framework/Versions
+        for path in $pyorg_dir/*
+            set py_version (basename $path)
+            # Using regex to filter out directories named as Major.Minor Python versions (e.g. 3.10)
+            if string match -q -r '^[0-9][.][0-9]{1,2}$' $py_version
+                echo $py_version
+            end
+        end
+    end
+
     # add completion for subcommands
     for sc in (functions -a | sed -n '/__vf_/{s///g;p;}')
         set -l helptext (functions "__vf_$sc" | grep -m1 "^function" | sed -E "s|.*'(.*)'.*|\1|")
@@ -806,8 +820,8 @@ function __vfsupport_setup_autocomplete --on-event virtualfish_did_setup_plugins
     complete -x -c vf -n '__vfcompletion_using_command rm' -a "(vf ls)"
     complete -x -c vf -n '__vfcompletion_using_command upgrade' -a "(vf ls)"
     # Optional: Autocomplete `vf new -p` and `vf upgrade -p` with Python versions installed via
-    # asdf or pyenv. To use, interactively execute `set -Ux VIRTUALFISH_PYVERSION_COMPLETION <"asdf"/"pyenv">`
-    # and reload your shell
+    # asdf, pyenv, or Python.org's Mac installer. To use, interactively execute
+    # `set -Ux VIRTUALFISH_PYVERSION_COMPLETION <"asdf"/"pyenv"/"pyorg">` and reload your shell
     if set -q VIRTUALFISH_PYVERSION_COMPLETION
         if test $VIRTUALFISH_PYVERSION_COMPLETION = "asdf"
             complete -x -c vf -n '__vfcompletion_using_command new' -s p -l python -a "(asdf list python 2> /dev/null | sed -e 's/^[[:space:]]*//')"
@@ -815,6 +829,9 @@ function __vfsupport_setup_autocomplete --on-event virtualfish_did_setup_plugins
         else if test $VIRTUALFISH_PYVERSION_COMPLETION = "pyenv"
             complete -x -c vf -n '__vfcompletion_using_command new' -s p -l python -a "(pyenv versions --bare)"
             complete -x -c vf -n '__vfcompletion_using_command upgrade' -s p -l python -a "(pyenv versions --bare)"
+        else if test $VIRTUALFISH_PYVERSION_COMPLETION = "pyorg"
+            complete -x -c vf -n '__vfcompletion_using_command new' -s p -l python -a "(__vfcompletion_pyorg_versions)"
+            complete -x -c vf -n '__vfcompletion_using_command upgrade' -s p -l python -a "(__vfcompletion_pyorg_versions)"
         end
     end
 


### PR DESCRIPTION
This brings the two previous commits together by adding autocompletions for Python versions installed with [Python.org's Mac installer](https://www.python.org/downloads/macos/). It adds another valid option to the `VIRTUALFISH_PYVERSION_COMPLETION` environment variable and an extra function to provide autocompletions of Python versions installed in `/Library/Frameworks/Python.framework/Versions`