### PR TITLE
Remove upper bounds on most dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,13 @@ psutil = ">=5.7"
 virtualenv = ">=20"
 
 [tool.poetry.dev-dependencies]
-black = "^22"
+black = ">=22"
 flake8 = "^3.9"
-pytest = "^6.1"
-pytest-sugar = "^0.9.5"
-pytest-xdist = "^2.1"
-sphinx = "^2.4"
-sphinx_rtd_theme = "^0.4"
+pytest = ">=6.1"
+pytest-sugar = ">=0.9.5"
+pytest-xdist = ">=2.1"
+sphinx = ">=5.1"
+sphinx_rtd_theme = ">=1.0"
 
 [tool.poetry.scripts]
 vf = "virtualfish.loader.cli:main"


### PR DESCRIPTION
Also increments Sphinx-related versions, which were quite old.

Flake8 remains pinned to 3.9.x until their war with the `importlib-metadata` people has been resolved.