### PR TITLE
Replace Setuptools for Python 3.12

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -17,7 +17,7 @@ assignees: ''
 
 <!-- Checked checkbox should look like this: [x] -->
 - [ ] I am using Fish shell version 3.1 or higher.
-- [ ] I am using Python version 3.6 or higher.
+- [ ] I am using Python version 3.8 or higher.
 - [ ] I have searched the [issues](https://github.com/justinmayer/virtualfish/issues?q=is%3Aissue) (including closed ones) and believe that this is not a duplicate.
 - [ ] If related to a plugin, I prefixed the issue title with the name of the plugin.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: v2.37.2
     hooks:
       - id: pyupgrade
-        args: [--py36-plus]
+        args: [--py38-plus]
 
   - repo: https://github.com/hakancelikdev/unimport
     rev: 0.9.6

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Resolve compatibility issue with Python 3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 "Tracker" = "https://github.com/justinmayer/virtualfish/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4.0"
+python = ">=3.8,<4.0"
 packaging = ">=21.3"
 pkgconfig = ">=1.5"
 psutil = ">=5.7"

--- a/virtualfish/loader/__init__.py
+++ b/virtualfish/loader/__init__.py
@@ -1,17 +1,16 @@
 import logging
 import os
 import sys
-import pkg_resources
-
+from importlib import metadata
 
 log = logging.getLogger(__name__)
 
 
 def load(plugins=(), full_install=True):
     try:
-        version = pkg_resources.get_distribution("virtualfish").version
+        version = metadata.version("virtualfish")
         commands = [f"set -g VIRTUALFISH_VERSION {version}"]
-    except pkg_resources.DistributionNotFound:
+    except metadata.PackageNotFoundError:
         commands = []
     base_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/virtualfish/virtual.fish
+++ b/virtualfish/virtual.fish
@@ -417,7 +417,7 @@ end
 
 function __vf_addpath --description "Adds a path to sys.path in this virtualenv"
     if set -q VIRTUAL_ENV
-        set -l site_packages (eval "$VIRTUAL_ENV/bin/python -c 'import distutils.sysconfig; print(distutils.sysconfig.get_python_lib())'")
+        set -l site_packages (eval "$VIRTUAL_ENV/bin/python -c 'import sysconfig; print(sysconfig.get_path(\'platlib\'))'")
         set -l path_file $site_packages/_virtualenv_path_extensions.pth
 
         set -l remove 0


### PR DESCRIPTION
Fixes #240 

Python 3.12 removed `distutils` and bundled `setuptools` (aka `pkg_resources`): https://docs.python.org/3.12/whatsnew/3.12.html#removed

Also bumps to python 3.8+ (since 3.7 is unsupported and would require a backport of `importlib.metadata`)
